### PR TITLE
feat: Bundle VictoriaMetrics binary and add license notices

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,20 +15,26 @@ jobs:
           - goos: linux
             goarch: amd64
             telegraf_suffix: linux_amd64
+            vm_suffix: linux-amd64
           - goos: linux
             goarch: arm64
             telegraf_suffix: linux_arm64
+            vm_suffix: linux-arm64
           - goos: darwin
             goarch: amd64
             telegraf_suffix: darwin_amd64
+            vm_suffix: darwin-amd64
           - goos: windows
             goarch: amd64
             telegraf_suffix: windows_amd64
+            vm_suffix: windows-amd64
             ext: .exe
 
     runs-on: ubuntu-latest
     env:
       TELEGRAF_VERSION: "1.29.0"
+      VM_VERSION: "1.133.0"
+      DEPS_TAG: "deps-v1"
 
     steps:
       - uses: actions/checkout@v4
@@ -45,14 +51,34 @@ jobs:
         run: |
           go build -ldflags="-s -w" -o edg-core${{ matrix.ext }} ./cmd/core
 
-      - name: Download Telegraf
+      - name: Download dependencies from own release
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
+          # Download Telegraf
           if [ "${{ matrix.goos }}" = "windows" ]; then
-            wget -q https://dl.influxdata.com/telegraf/releases/telegraf-${{ env.TELEGRAF_VERSION }}_${{ matrix.telegraf_suffix }}.zip
+            gh release download ${{ env.DEPS_TAG }} \
+              --pattern "telegraf-${{ env.TELEGRAF_VERSION }}-${{ matrix.goos }}-${{ matrix.goarch }}.zip" \
+              --repo ${{ github.repository }}
             unzip -q telegraf-*.zip
           else
-            wget -q https://dl.influxdata.com/telegraf/releases/telegraf-${{ env.TELEGRAF_VERSION }}_${{ matrix.telegraf_suffix }}.tar.gz
+            gh release download ${{ env.DEPS_TAG }} \
+              --pattern "telegraf-${{ env.TELEGRAF_VERSION }}-${{ matrix.goos }}-${{ matrix.goarch }}.tar.gz" \
+              --repo ${{ github.repository }}
             tar -xzf telegraf-*.tar.gz
+          fi
+
+          # Download VictoriaMetrics
+          if [ "${{ matrix.goos }}" = "windows" ]; then
+            gh release download ${{ env.DEPS_TAG }} \
+              --pattern "victoria-metrics-${{ matrix.vm_suffix }}-v${{ env.VM_VERSION }}.zip" \
+              --repo ${{ github.repository }}
+            unzip -q victoria-metrics-*.zip
+          else
+            gh release download ${{ env.DEPS_TAG }} \
+              --pattern "victoria-metrics-${{ matrix.vm_suffix }}-v${{ env.VM_VERSION }}.tar.gz" \
+              --repo ${{ github.repository }}
+            tar -xzf victoria-metrics-*.tar.gz
           fi
 
       - name: Package Release
@@ -64,13 +90,16 @@ jobs:
 
           if [ "${{ matrix.goos }}" = "windows" ]; then
             cp telegraf-*/telegraf.exe "$DIST_DIR/"
+            cp victoria-metrics-prod.exe "$DIST_DIR/" || cp victoria-metrics.exe "$DIST_DIR/victoria-metrics-prod.exe"
           else
             cp telegraf-*/usr/bin/telegraf "$DIST_DIR/"
+            cp victoria-metrics-prod "$DIST_DIR/" || cp victoria-metrics "$DIST_DIR/victoria-metrics-prod"
           fi
 
           cp -r configs "$DIST_DIR/"
           cp scripts/install.sh "$DIST_DIR/"
           cp README.md "$DIST_DIR/"
+          cp THIRD_PARTY_LICENSES.md "$DIST_DIR/"
 
           if [ "${{ matrix.goos }}" = "windows" ]; then
             zip -r "edg-${{ github.ref_name }}-${{ matrix.goos }}-${{ matrix.goarch }}.zip" "$DIST_DIR"

--- a/THIRD_PARTY_LICENSES.md
+++ b/THIRD_PARTY_LICENSES.md
@@ -1,0 +1,268 @@
+# Third-Party Licenses
+
+This document contains the license information for third-party software included in the EDG IoT Platform distribution.
+
+## Included Components
+
+| Component | Version | License | Copyright |
+|-----------|---------|---------|-----------|
+| Telegraf | 1.29.0 | MIT | 2015-2025 InfluxData Inc. |
+| VictoriaMetrics | 1.133.0 | Apache 2.0 | 2019-2025 VictoriaMetrics, Inc. |
+
+---
+
+## Telegraf
+
+**License**: MIT License
+**Copyright**: Copyright (c) 2015-2025 InfluxData Inc.
+**Source**: https://github.com/influxdata/telegraf
+
+### MIT License
+
+```
+MIT License
+
+Copyright (c) 2015-2025 InfluxData Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+```
+
+**Additional Information**:
+- Telegraf may contain dependencies licensed under various open-source licenses
+- For complete dependency license information, see: https://github.com/influxdata/telegraf/blob/master/docs/LICENSE_OF_DEPENDENCIES.md
+
+---
+
+## VictoriaMetrics
+
+**License**: Apache License 2.0
+**Copyright**: Copyright (c) 2019-2025 VictoriaMetrics, Inc.
+**Source**: https://github.com/VictoriaMetrics/VictoriaMetrics
+
+### Apache License 2.0
+
+```
+Apache License
+Version 2.0, January 2004
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+"License" shall mean the terms and conditions for use, reproduction, and
+distribution as defined by Sections 1 through 9 of this document.
+
+"Licensor" shall mean the copyright owner or entity authorized by the
+copyright owner that is granting the License.
+
+"Legal Entity" shall mean the union of the acting entity and all other
+entities that control, are controlled by, or are under common control with
+that entity. For the purposes of this definition, "control" means (i) the
+power, direct or indirect, to cause the direction or management of such
+entity, whether by contract or otherwise, or (ii) ownership of fifty
+percent (50%) or more of the outstanding shares, or (iii) beneficial
+ownership of such entity.
+
+"You" (or "Your") shall mean an individual or Legal Entity exercising
+permissions granted by this License.
+
+"Source" form shall mean the preferred form for making modifications,
+including but not limited to software source code, documentation source,
+and configuration files.
+
+"Object" form shall mean any form resulting from mechanical transformation
+or translation of a Source form, including but not limited to compiled
+object code, generated documentation, and conversions to other media types.
+
+"Work" shall mean the work of authorship, whether in Source or Object form,
+made available under the License, as indicated by a copyright notice that
+is included in or attached to the work (an example is provided in the
+Appendix below).
+
+"Derivative Works" shall mean any work, whether in Source or Object form,
+that is based on (or derived from) the Work and for which the editorial
+revisions, annotations, elaborations, or other modifications represent, as
+a whole, an original work of authorship. For the purposes of this License,
+Derivative Works shall not include works that remain separable from, or
+merely link (or bind by name) to the interfaces of, the Work and Derivative
+Works thereof.
+
+"Contribution" shall mean any work of authorship, including the original
+version of the Work and any modifications or additions to that Work or
+Derivative Works thereof, that is intentionally submitted to Licensor for
+inclusion in the Work by the copyright owner or by an individual or Legal
+Entity authorized to submit on behalf of the copyright owner. For the
+purposes of this definition, "submitted" means any form of electronic,
+verbal, or written communication sent to the Licensor or its
+representatives, including but not limited to communication on electronic
+mailing lists, source code control systems, and issue tracking systems that
+are managed by, or on behalf of, the Licensor for the purpose of discussing
+and improving the Work, but excluding communication that is conspicuously
+marked or otherwise designated in writing by the copyright owner as "Not a
+Contribution."
+
+"Contributor" shall mean Licensor and any individual or Legal Entity on
+behalf of whom a Contribution has been received by Licensor and
+subsequently incorporated within the Work.
+
+2. Grant of Copyright License.
+
+Subject to the terms and conditions of this License, each Contributor hereby
+grants to You a perpetual, worldwide, non-exclusive, no-charge,
+royalty-free, irrevocable copyright license to reproduce, prepare Derivative
+Works of, publicly display, publicly perform, sublicense, and distribute the
+Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License.
+
+Subject to the terms and conditions of this License, each Contributor hereby
+grants to You a perpetual, worldwide, non-exclusive, no-charge,
+royalty-free, irrevocable (except as stated in this section) patent license
+to make, have made, use, offer to sell, sell, import, and otherwise transfer
+the Work, where such license applies only to those patent claims licensable
+by such Contributor that are necessarily infringed by their Contribution(s)
+alone or by combination of their Contribution(s) with the Work to which such
+Contribution(s) was submitted. If You institute patent litigation against
+any entity (including a cross-claim or counterclaim in a lawsuit) alleging
+that the Work or a Contribution incorporated within the Work constitutes
+direct or contributory patent infringement, then any patent licenses granted
+to You under this License for that Work shall terminate as of the date such
+litigation is filed.
+
+4. Redistribution.
+
+You may reproduce and distribute copies of the Work or Derivative Works
+thereof in any medium, with or without modifications, and in Source or
+Object form, provided that You meet the following conditions:
+
+(a) You must give any other recipients of the Work or Derivative Works a
+    copy of this License; and
+
+(b) You must cause any modified files to carry prominent notices stating
+    that You changed the files; and
+
+(c) You must retain, in the Source form of any Derivative Works that You
+    distribute, all copyright, patent, trademark, and attribution notices
+    from the Source form of the Work, excluding those notices that do not
+    pertain to any part of the Derivative Works; and
+
+(d) If the Work includes a "NOTICE" text file as part of its distribution,
+    then any Derivative Works that You distribute must include a readable
+    copy of the attribution notices contained within such NOTICE file,
+    excluding those notices that do not pertain to any part of the
+    Derivative Works, in at least one of the following places: within a
+    NOTICE text file distributed as part of the Derivative Works; within
+    the Source form or documentation, if provided along with the Derivative
+    Works; or, within a display generated by the Derivative Works, if and
+    wherever such third-party notices normally appear. The contents of the
+    NOTICE file are for informational purposes only and do not modify the
+    License. You may add Your own attribution notices within Derivative
+    Works that You distribute, alongside or as an addendum to the NOTICE
+    text from the Work, provided that such additional attribution notices
+    cannot be construed as modifying the License.
+
+You may add Your own copyright statement to Your modifications and may
+provide additional or different license terms and conditions for use,
+reproduction, or distribution of Your modifications, or for any such
+Derivative Works as a whole, provided Your use, reproduction, and
+distribution of the Work otherwise complies with the conditions stated in
+this License.
+
+5. Submission of Contributions.
+
+Unless You explicitly state otherwise, any Contribution intentionally
+submitted for inclusion in the Work by You to the Licensor shall be under
+the terms and conditions of this License, without any additional terms or
+conditions. Notwithstanding the above, nothing herein shall supersede or
+modify the terms of any separate license agreement you may have executed
+with Licensor regarding such Contributions.
+
+6. Trademarks.
+
+This License does not grant permission to use the trade names, trademarks,
+service marks, or product names of the Licensor, except as required for
+reasonable and customary use in describing the origin of the Work and
+reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty.
+
+Unless required by applicable law or agreed to in writing, Licensor provides
+the Work (and each Contributor provides its Contributions) on an "AS IS"
+BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+implied, including, without limitation, any warranties or conditions of
+TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR
+PURPOSE. You are solely responsible for determining the appropriateness of
+using or redistributing the Work and assume any risks associated with Your
+exercise of permissions under this License.
+
+8. Limitation of Liability.
+
+In no event and under no legal theory, whether in tort (including
+negligence), contract, or otherwise, unless required by applicable law (such
+as deliberate and grossly negligent acts) or agreed to in writing, shall any
+Contributor be liable to You for damages, including any direct, indirect,
+special, incidental, or consequential damages of any character arising as a
+result of this License or out of the use or inability to use the Work
+(including but not limited to damages for loss of goodwill, work stoppage,
+computer failure or malfunction, or any and all other commercial damages or
+losses), even if such Contributor has been advised of the possibility of
+such damages.
+
+9. Accepting Warranty or Additional Liability.
+
+While redistributing the Work or Derivative Works thereof, You may choose to
+offer, and charge a fee for, acceptance of support, warranty, indemnity, or
+other liability obligations and/or rights consistent with this License.
+However, in accepting such obligations, You may act only on Your own behalf
+and on Your sole responsibility, not on behalf of any other Contributor, and
+only if You agree to indemnify, defend, and hold each Contributor harmless
+for any liability incurred by, or claims asserted against, such Contributor
+by reason of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+```
+
+**Full License Text**: https://www.apache.org/licenses/LICENSE-2.0
+**VictoriaMetrics License**: https://github.com/VictoriaMetrics/VictoriaMetrics/blob/master/LICENSE
+
+---
+
+## EDG Platform Go Dependencies
+
+The EDG Platform uses the following Go dependencies:
+
+| Dependency | License | Source |
+|-----------|---------|--------|
+| github.com/nats-io/nats-server/v2 | Apache 2.0 | https://github.com/nats-io/nats-server |
+| github.com/nats-io/nats.go | Apache 2.0 | https://github.com/nats-io/nats.go |
+| github.com/mattn/go-sqlite3 | MIT | https://github.com/mattn/go-sqlite3 |
+| github.com/google/uuid | BSD-3-Clause | https://github.com/google/uuid |
+| github.com/stretchr/testify | MIT | https://github.com/stretchr/testify |
+| gopkg.in/yaml.v3 | MIT/Apache 2.0 | https://github.com/go-yaml/yaml |
+
+For complete dependency information, see `go.mod` in the EDG Platform repository.
+
+---
+
+## License Compliance
+
+This distribution includes third-party software components. Each component's license must be respected when using, modifying, or distributing this software. The above licenses are provided for compliance and transparency.
+
+For questions about licensing, please contact the EDG Platform maintainers or refer to the original project repositories.

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -11,6 +11,7 @@ sudo mkdir -p "$INSTALL_DIR"/{bin,configs,data}
 # Copy binaries
 sudo cp edg-core "$INSTALL_DIR/bin/"
 sudo cp telegraf "$INSTALL_DIR/bin/"
+sudo cp victoria-metrics-prod "$INSTALL_DIR/bin/" 2>/dev/null || sudo cp victoria-metrics-prod.exe "$INSTALL_DIR/bin/" 2>/dev/null || true
 
 # Copy configs
 sudo cp -r configs/* "$INSTALL_DIR/configs/"
@@ -48,6 +49,22 @@ RestartSec=5
 WantedBy=multi-user.target
 EOF
 
+    # VictoriaMetrics service
+    sudo tee /etc/systemd/system/edg-victoriametrics.service > /dev/null <<EOF
+[Unit]
+Description=EDG VictoriaMetrics
+After=network.target
+
+[Service]
+ExecStart=$INSTALL_DIR/bin/victoria-metrics-prod -storageDataPath=$INSTALL_DIR/data/victoria-metrics -retentionPeriod=1y
+WorkingDirectory=$INSTALL_DIR
+Restart=always
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
     sudo systemctl daemon-reload
     echo "Systemd services registered."
 fi
@@ -55,5 +72,9 @@ fi
 echo "Installation complete: $INSTALL_DIR"
 echo ""
 echo "To start services:"
+echo "  sudo systemctl start edg-victoriametrics"
 echo "  sudo systemctl start edg-core"
 echo "  sudo systemctl start edg-telegraf"
+echo ""
+echo "To enable services at boot:"
+echo "  sudo systemctl enable edg-victoriametrics edg-core edg-telegraf"


### PR DESCRIPTION
## Overview
Bundle Telegraf and VictoriaMetrics binaries in release packages and meet license compliance requirements

Closes #13

## Changes

### 1. Created deps-v1 Release
- Binary-only release: https://github.com/e7217/edg/releases/tag/deps-v1
- Telegraf 1.29.0 (4 platforms)
- VictoriaMetrics 1.133.0 (4 platforms)
- Removed external URL dependencies

### 2. License Notices
- Added `THIRD_PARTY_LICENSES.md`
- Included full Telegraf MIT License text
- Included VictoriaMetrics Apache 2.0 License
- Summarized Go dependency licenses

### 3. Build Workflow Improvements
- Updated `.github/workflows/release.yml`
- Download from deps-v1 release instead of external sites
- Added VictoriaMetrics binary packaging
- Include THIRD_PARTY_LICENSES.md in packages

### 4. Installation Script Improvements
- Updated `scripts/install.sh`
- Added VictoriaMetrics binary installation
- Register `edg-victoriametrics.service` systemd service
- Data path: `/opt/edg/data/victoria-metrics`
- Retention period: 1 year

## Package Structure
```
edg-v1.x.x-linux-amd64.tar.gz
├── edg-core
├── telegraf
├── victoria-metrics-prod        ← Added
├── configs/telegraf/
├── scripts/install.sh
├── THIRD_PARTY_LICENSES.md      ← Added
└── README.md
```

## Test Plan
- [ ] Verify auto-build success on tag creation
- [ ] Validate package structure (all binaries included)
- [ ] Test installation script execution
- [ ] Verify systemd services work correctly
- [ ] Test VictoriaMetrics connectivity (http://localhost:8428)

## License Compliance
- ✅ MIT License (Telegraf): Copyright notice and full text included
- ✅ Apache 2.0 (VictoriaMetrics): LICENSE reference and copyright notice
- ✅ THIRD_PARTY_LICENSES.md included in release packages
