### PR TITLE
fix: correct Telegraf environment variable substitution syntax

### DIFF
--- a/configs/telegraf/telegraf.conf
+++ b/configs/telegraf/telegraf.conf
@@ -9,7 +9,7 @@
 
 # NATS Consumer - receive validated data from EDG Core
 [[inputs.nats_consumer]]
-  servers = ["nats://${NATS_SERVER:localhost}:${NATS_PORT:4222}"]
+  servers = ["nats://${NATS_SERVER:-localhost}:${NATS_PORT:-4222}"]
   subjects = ["platform.data.validated"]
   queue_group = "telegraf"
   data_format = "json_v2"
@@ -26,7 +26,7 @@
 
 # VictoriaMetrics output (InfluxDB v2 compatible)
 [[outputs.influxdb_v2]]
-  urls = ["http://${VM_HOST:localhost}:${VM_PORT:8428}"]
+  urls = ["http://${VM_HOST:-localhost}:${VM_PORT:-8428}"]
   token = ""
   organization = "edg"
   bucket = "sensors"


### PR DESCRIPTION
## Summary
Fixed Telegraf configuration to use correct environment variable substitution syntax.

## Problem
Telegraf was failing to parse environment variables due to incorrect bash-style syntax `${VAR:default}`, causing connection failures to VictoriaMetrics.

## Changes
- Updated `configs/telegraf/telegraf.conf` to use Telegraf/Go standard syntax `${VAR:-default}`
- Fixed NATS_SERVER, NATS_PORT, VM_HOST, VM_PORT variable substitution

## Test Plan
- [ ] Rebuild Telegraf container: `docker-compose up -d --build edg-telegraf`
- [ ] Verify logs show successful connection: `docker-compose logs -f edg-telegraf`
- [ ] Confirm no parsing errors in startup logs
- [ ] Verify metrics are flowing to VictoriaMetrics

## Impact
- Telegraf can now connect to VictoriaMetrics successfully
- Environment variables from docker-compose are properly substituted
- No more parsing errors on container startup

Resolves #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)