### PR TITLE
fix: Handle JSON marshaling errors in store.go

### DIFF
--- a/internal/core/store.go
+++ b/internal/core/store.go
@@ -115,7 +115,9 @@ func (s *Store) GetAsset(id string) (*Asset, error) {
 		return nil, fmt.Errorf("failed to get asset: %w", err)
 	}
 
-	json.Unmarshal([]byte(labelsJSON), &asset.Labels)
+	if err := json.Unmarshal([]byte(labelsJSON), &asset.Labels); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal asset labels: %w", err)
+	}
 	return &asset, nil
 }
 
@@ -136,7 +138,9 @@ func (s *Store) GetAssetByName(name string) (*Asset, error) {
 		return nil, fmt.Errorf("failed to get asset: %w", err)
 	}
 
-	json.Unmarshal([]byte(labelsJSON), &asset.Labels)
+	if err := json.Unmarshal([]byte(labelsJSON), &asset.Labels); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal asset labels: %w", err)
+	}
 	return &asset, nil
 }
 
@@ -157,7 +161,9 @@ func (s *Store) ListAssets() ([]*Asset, error) {
 		if err := rows.Scan(&asset.ID, &asset.Name, &asset.TemplateName, &labelsJSON, &asset.CreatedAt); err != nil {
 			return nil, err
 		}
-		json.Unmarshal([]byte(labelsJSON), &asset.Labels)
+		if err := json.Unmarshal([]byte(labelsJSON), &asset.Labels); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal asset labels: %w", err)
+		}
 		assets = append(assets, &asset)
 	}
 
@@ -292,7 +298,9 @@ func (s *Store) GetRelation(id string) (*AssetRelation, error) {
 
 	// Unmarshal metadata if present
 	if metadataJSON.Valid && metadataJSON.String != "" {
-		json.Unmarshal([]byte(metadataJSON.String), &relation.Metadata)
+		if err := json.Unmarshal([]byte(metadataJSON.String), &relation.Metadata); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal relation metadata: %w", err)
+		}
 	}
 
 	return &relation, nil
@@ -322,7 +330,9 @@ func (s *Store) GetRelationsBySourceAsset(assetID string) ([]*AssetRelation, err
 		}
 
 		if metadataJSON.Valid && metadataJSON.String != "" {
-			json.Unmarshal([]byte(metadataJSON.String), &relation.Metadata)
+			if err := json.Unmarshal([]byte(metadataJSON.String), &relation.Metadata); err != nil {
+				return nil, fmt.Errorf("failed to unmarshal relation metadata: %w", err)
+			}
 		}
 
 		relations = append(relations, &relation)
@@ -355,7 +365,9 @@ func (s *Store) GetRelationsByTargetAsset(assetID string) ([]*AssetRelation, err
 		}
 
 		if metadataJSON.Valid && metadataJSON.String != "" {
-			json.Unmarshal([]byte(metadataJSON.String), &relation.Metadata)
+			if err := json.Unmarshal([]byte(metadataJSON.String), &relation.Metadata); err != nil {
+				return nil, fmt.Errorf("failed to unmarshal relation metadata: %w", err)
+			}
 		}
 
 		relations = append(relations, &relation)


### PR DESCRIPTION
## Summary
Fixes #2 

Added proper error handling for `json.Unmarshal` calls in `store.go` that were previously ignoring errors, which could lead to silent data corruption and hard-to-debug runtime issues.

## Changes

### Modified Files
- `internal/core/store.go` - Added error handling to 6 locations
- `internal/core/store_test.go` - Added 6 new test cases for invalid JSON scenarios

### Error Handling Added (6 locations)
| Function | Line | Description |
|----------|------|-------------|
| `GetAsset` | 118 | Handle asset labels unmarshal errors |
| `GetAssetByName` | 141 | Handle asset labels unmarshal errors |
| `ListAssets` | 164 | Handle asset labels unmarshal errors |
| `GetRelation` | 301 | Handle relation metadata unmarshal errors |
| `GetRelationsBySourceAsset` | 333 | Handle relation metadata unmarshal errors |
| `GetRelationsByTargetAsset` | 368 | Handle relation metadata unmarshal errors |

### New Test Cases (6 tests)
- `TestGetAsset_InvalidLabelsJSON`
- `TestGetAssetByName_InvalidLabelsJSON`
- `TestListAssets_InvalidLabelsJSON`
- `TestGetRelation_InvalidMetadataJSON`
- `TestGetRelationsBySourceAsset_InvalidMetadataJSON`
- `TestGetRelationsByTargetAsset_InvalidMetadataJSON`

## Test Results
✅ All 63 tests passing (57 existing + 6 new)  
✅ No regressions in existing functionality  
✅ `go vet` passes without errors

## Implementation Approach
Followed TDD methodology:
1. **RED** - Wrote 6 failing tests with malformed JSON
2. **GREEN** - Added error handling to make tests pass
3. **VERIFY** - Confirmed all tests pass and no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)