### PR TITLE
feat: document data plane reliability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Documented the data plane reliability model in ADR 0001
+- Added configurable JetStream stream policy and dead-letter subject handling
+- Added Go chaos regressions for JetStream backlog recovery, discard pressure,
+  concurrent asset auto-registration, and dead-letter publication
 - Initial EDG Platform Core implementation with embedded NATS server
 - Metadata storage system using SQLite database
 - Template loading and management system

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 ## Why EDG?
 
 *   **Lightweight & Fast**: Built with Go and NATS for ultra-low latency.
-*   **Reliable**: Built-in data validation and auto-registration of assets.
+*   **Reliable**: Built-in data validation, auto-registration of assets, and documented JetStream durability boundaries.
 *   **Plug & Play**: Simple Python adapters for reading any sensor data.
 *   **Time-Series Ready**: Seamless integration with VictoriaMetrics/InfluxDB via Telegraf.
 
@@ -25,7 +25,7 @@
 
 *   **Automatic Asset Registration**: Device discovery and metadata registration without manual configuration.
 *   **Data Validation**: Enforces schema and quality checks at the edge before data enters your storage.
-*   **At-Least-Once Delivery**: Uses NATS JetStream to ensure zero data loss even during network outages.
+*   **At-Least-Once Delivery**: Uses NATS JetStream for durable delivery after core publish acknowledgement. See [ADR 0001](docs/adr/0001-data-plane-reliability.md) for the exact reliability boundary.
 *   **Flexible Adapters**: Easily write collectors in Python for Modbus, OPC-UA, or custom protocols.
 
 ## Quick Start
@@ -115,6 +115,7 @@ We are evolving from a data collector to a full **Bidirectional IoT Gateway**.
 
 *   **[User Guide](docs/USER_GUIDE.md)**: Detailed installation, configuration, and monitoring.
 *   **[Developer Guide](docs/DEVELOPMENT.md)**: Building from source, contributing, and architecture details.
+*   **[Architecture Decisions](docs/adr/README.md)**: Runtime and reliability decisions.
 
 ## Grafana (Optional)
 

--- a/cmd/core/main.go
+++ b/cmd/core/main.go
@@ -26,6 +26,7 @@ func main() {
 	// Parse command-line flags
 	versionFlag := flag.Bool("version", false, "Print version information and exit")
 	migrateDownFlag := flag.Int("migrate-down", 0, "Rollback metadata DB by N migration steps and exit")
+	configFlag := flag.String("config", os.Getenv("EDG_CORE_CONFIG"), "Path to core configuration file")
 	flag.Parse()
 
 	// Handle version flag
@@ -37,9 +38,18 @@ func main() {
 		os.Exit(0)
 	}
 
-	metadataDBPath := "./data/metadata.db"
+	configPath := *configFlag
+	if configPath == "" {
+		configPath = discoverConfigPath()
+	}
+
+	cfg, err := core.LoadCoreConfig(configPath)
+	if err != nil {
+		log.Fatalf("Failed to load core config: %v", err)
+	}
+
 	if *migrateDownFlag > 0 {
-		if err := core.RunMigrationSteps(metadataDBPath, -*migrateDownFlag); err != nil {
+		if err := core.RunMigrationSteps(cfg.Storage.MetadataDB, -*migrateDownFlag); err != nil {
 			log.Fatalf("Failed to rollback metadata DB: %v", err)
 		}
 		log.Printf("[Core] Rolled back metadata DB by %d migration step(s)", *migrateDownFlag)
@@ -48,10 +58,10 @@ func main() {
 
 	// 1. Embedded NATS Server configuration
 	opts := &server.Options{
-		Port:      4222,
-		HTTPPort:  8222, // for monitoring
-		JetStream: true, // Enable JetStream for message persistence
-		StoreDir:  "./data/jetstream",
+		Port:      cfg.NATS.Port,
+		HTTPPort:  cfg.NATS.HTTPPort, // for monitoring
+		JetStream: true,              // Enable JetStream for message persistence
+		StoreDir:  cfg.NATS.StoreDir,
 	}
 
 	ns, err := server.NewServer(opts)
@@ -69,12 +79,12 @@ func main() {
 
 	log.Println("=================================")
 	log.Println("  EDG Platform Core Started")
-	log.Println("  NATS: nats://localhost:4222")
-	log.Println("  Monitor: http://localhost:8222")
+	log.Printf("  NATS: nats://localhost:%d", cfg.NATS.Port)
+	log.Printf("  Monitor: http://localhost:%d", cfg.NATS.HTTPPort)
 	log.Println("=================================")
 
 	// 3. Connect as internal client
-	nc, err := nats.Connect(nats.DefaultURL)
+	nc, err := nats.Connect(fmt.Sprintf("nats://localhost:%d", cfg.NATS.Port))
 	if err != nil {
 		log.Fatalf("Failed to connect to NATS: %v", err)
 	}
@@ -86,31 +96,29 @@ func main() {
 		log.Fatalf("Failed to create JetStream context: %v", err)
 	}
 
-	// 3.2. Create JetStream stream for platform data
-	streamName := "PLATFORM_DATA"
-	_, err = js.StreamInfo(streamName)
+	// 3.2. Create or align JetStream stream for platform data
+	streamConfig, err := cfg.JetStream.Stream.NATSConfig()
+	if err != nil {
+		log.Fatalf("Invalid JetStream stream config: %v", err)
+	}
+
+	_, err = js.StreamInfo(streamConfig.Name)
 	if err != nil {
 		// Stream doesn't exist, create it
-		_, err = js.AddStream(&nats.StreamConfig{
-			Name:     streamName,
-			Subjects: []string{"platform.data.>"},
-			Storage:  nats.FileStorage,
-			MaxAge:   7 * 24 * time.Hour, // 7 days retention
-		})
+		_, err = js.AddStream(streamConfig)
 		if err != nil {
 			log.Fatalf("Failed to create JetStream stream: %v", err)
 		}
-		log.Printf("[Core] Created JetStream stream: %s", streamName)
+		log.Printf("[Core] Created JetStream stream: %s", streamConfig.Name)
 	} else {
-		log.Printf("[Core] JetStream stream already exists: %s", streamName)
+		if _, err := js.UpdateStream(streamConfig); err != nil {
+			log.Fatalf("Failed to update JetStream stream: %v", err)
+		}
+		log.Printf("[Core] JetStream stream aligned: %s", streamConfig.Name)
 	}
 
 	// 4. Initialize metadata store
-	if err := core.RunMigrations(metadataDBPath); err != nil {
-		log.Fatalf("Failed to migrate metadata DB: %v", err)
-	}
-
-	store, err := core.NewStore(metadataDBPath)
+	store, err := core.NewStoreWithMigrations(cfg.Storage.MetadataDB, cfg.Storage.AutoMigrate)
 	if err != nil {
 		log.Fatalf("Failed to create store: %v", err)
 	}
@@ -118,13 +126,18 @@ func main() {
 
 	// 5. Initialize template loader
 	loader := core.NewTemplateLoader()
-	if err := loader.LoadFromDir("./templates"); err != nil {
+	if err := loader.LoadFromDir(cfg.Templates.Dir); err != nil {
 		log.Printf("[Core] Warning: Failed to load templates: %v", err)
 	}
 	log.Printf("[Core] Loaded %d templates", loader.Count())
 
 	// 6. Create handlers and subscribe
-	dataHandler := core.NewDataHandler(js, store)
+	dataHandler := core.NewDataHandlerWithSubjects(
+		js,
+		store,
+		cfg.JetStream.ValidatedSubject,
+		cfg.JetStream.DeadLetterSubject,
+	)
 	metaHandler := core.NewMetaHandler(store, loader)
 
 	_, err = nc.Subscribe("platform.data.asset", dataHandler.HandleAssetData)
@@ -146,4 +159,16 @@ func main() {
 	log.Println("[Core] Shutting down...")
 	nc.Drain()
 	ns.Shutdown()
+}
+
+func discoverConfigPath() string {
+	for _, path := range []string{
+		"/opt/edg/config.yaml",
+		"deploy/configs/core/config.dev.yaml",
+	} {
+		if _, err := os.Stat(path); err == nil {
+			return path
+		}
+	}
+	return ""
 }

--- a/cmd/core/main_test.go
+++ b/cmd/core/main_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -83,5 +84,27 @@ func TestVersionVariables(t *testing.T) {
 				t.Errorf("Expected %q to have a default value", tt.name)
 			}
 		})
+	}
+}
+
+func TestDiscoverConfigPathFindsDevConfig(t *testing.T) {
+	if _, err := os.Stat("/opt/edg/config.yaml"); err == nil {
+		t.Skip("/opt/edg/config.yaml exists on this machine")
+	}
+
+	configPath := filepath.Join("deploy", "configs", "core", "config.dev.yaml")
+	if err := os.MkdirAll(filepath.Dir(configPath), 0755); err != nil {
+		t.Fatalf("failed to create test config directory: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = os.RemoveAll("deploy")
+	})
+
+	if err := os.WriteFile(configPath, []byte("nats:\n  port: 4222\n"), 0644); err != nil {
+		t.Fatalf("failed to write test config: %v", err)
+	}
+
+	if got := discoverConfigPath(); got != configPath {
+		t.Fatalf("discoverConfigPath() = %q, want %q", got, configPath)
 	}
 }

--- a/deploy/configs/core/config.dev.yaml
+++ b/deploy/configs/core/config.dev.yaml
@@ -3,6 +3,7 @@
 nats:
   port: 4222
   http_port: 8222
+  store_dir: ./data/jetstream
   log_level: debug
 
 storage:
@@ -14,6 +15,20 @@ storage:
 templates:
   dir: ./templates
   auto_reload: true
+
+jetstream:
+  validated_subject: platform.data.validated
+  dead_letter_subject: platform.data.deadletter
+  stream:
+    name: PLATFORM_DATA
+    subjects:
+      - platform.data.>
+    storage: file
+    max_age: 168h
+    max_bytes: 1073741824
+    replicas: 1
+    retention: limits
+    discard: old
 
 logging:
   level: debug

--- a/deploy/configs/core/config.prod.yaml
+++ b/deploy/configs/core/config.prod.yaml
@@ -3,6 +3,7 @@
 nats:
   port: 4222
   http_port: 8222
+  store_dir: /var/lib/edg/data/jetstream
   log_level: warn
 
 storage:
@@ -14,6 +15,20 @@ storage:
 templates:
   dir: /etc/edg/templates
   auto_reload: false
+
+jetstream:
+  validated_subject: platform.data.validated
+  dead_letter_subject: platform.data.deadletter
+  stream:
+    name: PLATFORM_DATA
+    subjects:
+      - platform.data.>
+    storage: file
+    max_age: 168h
+    max_bytes: 1073741824
+    replicas: 1
+    retention: limits
+    discard: old
 
 logging:
   level: warn

--- a/deploy/configs/core/config.staging.yaml
+++ b/deploy/configs/core/config.staging.yaml
@@ -3,6 +3,7 @@
 nats:
   port: 4222
   http_port: 8222
+  store_dir: /var/lib/edg/data/jetstream
   log_level: info
 
 storage:
@@ -14,6 +15,20 @@ storage:
 templates:
   dir: /etc/edg/templates
   auto_reload: true
+
+jetstream:
+  validated_subject: platform.data.validated
+  dead_letter_subject: platform.data.deadletter
+  stream:
+    name: PLATFORM_DATA
+    subjects:
+      - platform.data.>
+    storage: file
+    max_age: 168h
+    max_bytes: 1073741824
+    replicas: 1
+    retention: limits
+    discard: old
 
 logging:
   level: info

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -63,6 +63,42 @@ INSTALL_DIR=/custom/path ./install.sh
 - **Data Storage**: `./data/metadata.db` (auto-created)
 - **Schema Migrations**: embedded migrations run automatically on startup
 - **Templates**: `./templates/` (optional)
+- **Config file**: set `EDG_CORE_CONFIG` or pass `--config` to choose a core YAML file.
+
+**JetStream reliability defaults:**
+```yaml
+jetstream:
+  validated_subject: platform.data.validated
+  dead_letter_subject: platform.data.deadletter
+  stream:
+    name: PLATFORM_DATA
+    subjects:
+      - platform.data.>
+    storage: file
+    max_age: 168h
+    max_bytes: 1073741824
+    replicas: 1
+    retention: limits
+    discard: old
+```
+
+## What "Reliable" Means
+
+EDG persists data after the core successfully publishes validated data to
+JetStream and receives a publish acknowledgement. The adapter-to-core hop is
+plain NATS pub/sub, so adapters that need stronger end-to-end guarantees should
+retry or buffer before publishing.
+
+If publishing to `platform.data.validated` fails, core attempts to publish a JSON
+failure envelope to `platform.data.deadletter`. Monitor these expvar counters on
+the core process:
+
+- `edg_core_jetstream_publish_failures`
+- `edg_core_jetstream_dead_letters`
+- `edg_core_jetstream_dead_letter_failures`
+
+See [ADR 0001](adr/0001-data-plane-reliability.md) for the reliability model and
+failure-mode tradeoffs.
 
 ### Telegraf
 Configuration file: `/opt/edg/configs/telegraf/telegraf.conf`

--- a/docs/adr/0001-data-plane-reliability.md
+++ b/docs/adr/0001-data-plane-reliability.md
@@ -1,0 +1,83 @@
+# ADR 0001: Data Plane Reliability
+
+## Status
+
+Accepted
+
+## Context
+
+EDG advertises reliable edge ingestion, but the current data plane has multiple
+hops with different delivery semantics. The adapter-to-core hop uses plain NATS
+pub/sub. The core-to-storage hop uses NATS JetStream. Telegraf then consumes the
+validated stream and writes to VictoriaMetrics.
+
+The reliability claim must be explicit enough for operators and adapter authors
+to know where EDG provides persistence and where callers still need retry or
+buffering.
+
+## Decision
+
+EDG defines "at-least-once delivery" as starting after the core receives a
+successful JetStream publish acknowledgement for `platform.data.validated`.
+
+The default stream policy is:
+
+| Field | Value |
+|---|---|
+| Stream | `PLATFORM_DATA` |
+| Subjects | `platform.data.>` |
+| Storage | `file` |
+| Retention | `limits` |
+| Max age | `168h` / 7 days |
+| Max bytes | `1073741824` / 1 GiB |
+| Replicas | `1` |
+| Discard | `old` |
+
+The subject model is:
+
+| Subject | Meaning |
+|---|---|
+| `platform.data.asset` | Raw adapter input received by core. |
+| `platform.data.validated` | Core-accepted payload published with JetStream ack. |
+| `platform.data.deadletter` | Publish failure envelope for data that could not be persisted to the validated subject. |
+
+The hop model is:
+
+| Hop | Delivery model | Responsibility |
+|---|---|---|
+| Adapter to core | At-most-once NATS pub/sub | Adapters retry or buffer when stronger guarantees are needed. |
+| Core to JetStream | Publish ack required | Core records publish failures and attempts dead-letter publication. |
+| JetStream to Telegraf | Durable consumer | Telegraf acks after successful downstream write. |
+
+The core exposes expvar counters:
+
+| Counter | Meaning |
+|---|---|
+| `edg_core_jetstream_publish_failures` | Validated publish attempts that failed. |
+| `edg_core_jetstream_dead_letters` | Failed validated publishes successfully written to the dead-letter subject. |
+| `edg_core_jetstream_dead_letter_failures` | Dead-letter encoding or publish failures. |
+
+## Consequences
+
+Operators can size JetStream storage by changing `jetstream.stream.max_bytes` in
+the core configuration. When the stream reaches the byte limit, JetStream uses
+`DiscardOld`, so the oldest retained messages are removed first. Operators must
+monitor stream state and the dead-letter counters to detect data loss pressure.
+
+Single-node deployments use one replica. Multi-node replication is out of scope
+for this decision and requires a later ADR because it changes deployment,
+storage, and upgrade requirements.
+
+Adapter authors must not treat a successful plain NATS publish as durable
+storage. Adapters that need end-to-end acknowledgement should use a later
+request/reply or SDK-level acknowledgement pattern.
+
+## Validation
+
+The core test suite includes regression coverage for:
+
+- JetStream backlog recovery after a consumer attaches.
+- `DiscardOld` behavior under small `MaxBytes` pressure.
+- Concurrent auto-registration of the same asset.
+- Dead-letter publication when the validated publish ack fails.
+

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,14 @@
+# Architecture Decision Records
+
+This directory records EDG architecture decisions that affect runtime behavior,
+operator expectations, or compatibility.
+
+## Records
+
+- [ADR 0001: Data Plane Reliability](0001-data-plane-reliability.md)
+
+## Format
+
+ADRs use a lightweight MADR-style structure: context, decision, consequences,
+and validation. See <https://adr.github.io/madr/> for the full template.
+

--- a/internal/core/chaos_test.go
+++ b/internal/core/chaos_test.go
@@ -1,0 +1,125 @@
+package core
+
+import (
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/nats-io/nats.go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestChaosJetStream_BacklogRecoversWhenConsumerAttaches(t *testing.T) {
+	_, _, js := startTestNATSServer(t, true)
+
+	_, err := js.AddStream(&nats.StreamConfig{
+		Name:     "BACKLOG_TEST",
+		Subjects: []string{"platform.data.>"},
+		Storage:  nats.MemoryStorage,
+		MaxMsgs:  100,
+	})
+	require.NoError(t, err)
+
+	handler := NewDataHandler(js, nil)
+	for i := 0; i < 10; i++ {
+		handler.HandleAssetData(assetDataMessage(t, fmt.Sprintf("sensor-%03d", i), float64(i)))
+	}
+
+	info, err := js.StreamInfo("BACKLOG_TEST")
+	require.NoError(t, err)
+	require.Equal(t, uint64(10), info.State.Msgs)
+
+	sub, err := js.PullSubscribe("platform.data.validated", "vm-writer")
+	require.NoError(t, err)
+	defer sub.Unsubscribe()
+
+	msgs, err := sub.Fetch(10, nats.MaxWait(2*time.Second))
+	require.NoError(t, err)
+	require.Len(t, msgs, 10)
+	for _, msg := range msgs {
+		require.NoError(t, msg.Ack())
+	}
+}
+
+func TestChaosJetStream_DiscardOldUnderMaxBytesPressure(t *testing.T) {
+	_, _, js := startTestNATSServer(t, true)
+
+	_, err := js.AddStream(&nats.StreamConfig{
+		Name:     "PRESSURE_TEST",
+		Subjects: []string{"pressure.data"},
+		Storage:  nats.FileStorage,
+		MaxBytes: 96,
+		Discard:  nats.DiscardOld,
+	})
+	require.NoError(t, err)
+
+	for i := 0; i < 5; i++ {
+		_, err := js.Publish("pressure.data", []byte(fmt.Sprintf("message-%d-with-padding", i)))
+		require.NoError(t, err)
+	}
+
+	info, err := js.StreamInfo("PRESSURE_TEST")
+	require.NoError(t, err)
+	assert.Less(t, info.State.Msgs, uint64(5))
+	assert.Greater(t, info.State.FirstSeq, uint64(1))
+}
+
+func TestChaosDataHandler_ConcurrentAutoRegistrationSingleAsset(t *testing.T) {
+	_, _, js := startTestNATSServer(t, true)
+
+	_, err := js.AddStream(&nats.StreamConfig{
+		Name:     "RACE_TEST",
+		Subjects: []string{"platform.data.>"},
+		Storage:  nats.MemoryStorage,
+	})
+	require.NoError(t, err)
+
+	store, err := NewStore(filepath.Join(t.TempDir(), "metadata.db"))
+	require.NoError(t, err)
+	defer store.Close()
+
+	handler := NewDataHandler(js, store)
+	msg := assetDataMessage(t, "shared-asset", 42)
+
+	var wg sync.WaitGroup
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			handler.HandleAssetData(msg)
+		}()
+	}
+	wg.Wait()
+
+	asset, err := store.GetAsset("shared-asset")
+	require.NoError(t, err)
+	require.NotNil(t, asset)
+
+	assets, err := store.ListAssets()
+	require.NoError(t, err)
+	assert.Len(t, assets, 1)
+	assert.Equal(t, 100, handler.GetDataCount())
+}
+
+func assetDataMessage(t *testing.T, assetID string, value float64) *nats.Msg {
+	t.Helper()
+
+	data := &AssetData{
+		AssetID:   assetID,
+		Timestamp: time.Now().UnixNano(),
+		Values: []TagValue{
+			{Name: "temperature", Number: &value, Unit: "celsius", Quality: "good"},
+		},
+	}
+	payload, err := json.Marshal(data)
+	require.NoError(t, err)
+
+	return &nats.Msg{
+		Subject: "platform.data.asset",
+		Data:    payload,
+	}
+}

--- a/internal/core/config.go
+++ b/internal/core/config.go
@@ -1,0 +1,277 @@
+package core
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/nats-io/nats.go"
+	"gopkg.in/yaml.v3"
+)
+
+const (
+	DefaultValidatedDataSubject = "platform.data.validated"
+	DefaultDeadLetterSubject    = "platform.data.deadletter"
+)
+
+// CoreConfig contains runtime settings for the embedded core process.
+type CoreConfig struct {
+	NATS      NATSConfig      `yaml:"nats"`
+	Storage   StorageConfig   `yaml:"storage"`
+	Templates TemplateConfig  `yaml:"templates"`
+	Logging   LoggingConfig   `yaml:"logging"`
+	JetStream JetStreamConfig `yaml:"jetstream"`
+}
+
+type NATSConfig struct {
+	Port     int    `yaml:"port"`
+	HTTPPort int    `yaml:"http_port"`
+	LogLevel string `yaml:"log_level"`
+	StoreDir string `yaml:"store_dir"`
+}
+
+type StorageConfig struct {
+	MetadataDB    string `yaml:"metadata_db"`
+	DataDir       string `yaml:"data_dir"`
+	MigrationsDir string `yaml:"migrations_dir"`
+	AutoMigrate   bool   `yaml:"auto_migrate"`
+}
+
+type TemplateConfig struct {
+	Dir        string `yaml:"dir"`
+	AutoReload bool   `yaml:"auto_reload"`
+}
+
+type LoggingConfig struct {
+	Level  string `yaml:"level"`
+	Format string `yaml:"format"`
+}
+
+type JetStreamConfig struct {
+	Stream            JetStreamStreamConfig `yaml:"stream"`
+	ValidatedSubject  string                `yaml:"validated_subject"`
+	DeadLetterSubject string                `yaml:"dead_letter_subject"`
+}
+
+type JetStreamStreamConfig struct {
+	Name      string        `yaml:"name"`
+	Subjects  []string      `yaml:"subjects"`
+	Storage   string        `yaml:"storage"`
+	MaxAge    time.Duration `yaml:"max_age"`
+	MaxBytes  int64         `yaml:"max_bytes"`
+	Replicas  int           `yaml:"replicas"`
+	Retention string        `yaml:"retention"`
+	Discard   string        `yaml:"discard"`
+}
+
+// DefaultCoreConfig returns the ADR-backed reliability defaults.
+func DefaultCoreConfig() CoreConfig {
+	return CoreConfig{
+		NATS: NATSConfig{
+			Port:     4222,
+			HTTPPort: 8222,
+			LogLevel: "info",
+			StoreDir: "./data/jetstream",
+		},
+		Storage: StorageConfig{
+			MetadataDB:    "./data/metadata.db",
+			DataDir:       "./data",
+			MigrationsDir: "embedded",
+			AutoMigrate:   true,
+		},
+		Templates: TemplateConfig{
+			Dir:        "./templates",
+			AutoReload: true,
+		},
+		Logging: LoggingConfig{
+			Level:  "info",
+			Format: "text",
+		},
+		JetStream: JetStreamConfig{
+			ValidatedSubject:  DefaultValidatedDataSubject,
+			DeadLetterSubject: DefaultDeadLetterSubject,
+			Stream: JetStreamStreamConfig{
+				Name:      "PLATFORM_DATA",
+				Subjects:  []string{"platform.data.>"},
+				Storage:   "file",
+				MaxAge:    7 * 24 * time.Hour,
+				MaxBytes:  1024 * 1024 * 1024,
+				Replicas:  1,
+				Retention: "limits",
+				Discard:   "old",
+			},
+		},
+	}
+}
+
+func LoadCoreConfig(path string) (CoreConfig, error) {
+	cfg := DefaultCoreConfig()
+	if path == "" {
+		return cfg, nil
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return cfg, fmt.Errorf("failed to read core config: %w", err)
+	}
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		return cfg, fmt.Errorf("failed to parse core config: %w", err)
+	}
+	cfg.applyDefaults()
+	return cfg, nil
+}
+
+func (c *CoreConfig) applyDefaults() {
+	defaults := DefaultCoreConfig()
+
+	if c.NATS.Port == 0 {
+		c.NATS.Port = defaults.NATS.Port
+	}
+	if c.NATS.HTTPPort == 0 {
+		c.NATS.HTTPPort = defaults.NATS.HTTPPort
+	}
+	if c.NATS.StoreDir == "" {
+		c.NATS.StoreDir = defaults.NATS.StoreDir
+	}
+	if c.Storage.MetadataDB == "" {
+		c.Storage.MetadataDB = defaults.Storage.MetadataDB
+	}
+	if c.Storage.DataDir == "" {
+		c.Storage.DataDir = defaults.Storage.DataDir
+	}
+	if c.Storage.MigrationsDir == "" {
+		c.Storage.MigrationsDir = defaults.Storage.MigrationsDir
+	}
+	if c.Templates.Dir == "" {
+		c.Templates.Dir = defaults.Templates.Dir
+	}
+	if c.JetStream.ValidatedSubject == "" {
+		c.JetStream.ValidatedSubject = defaults.JetStream.ValidatedSubject
+	}
+	if c.JetStream.DeadLetterSubject == "" {
+		c.JetStream.DeadLetterSubject = defaults.JetStream.DeadLetterSubject
+	}
+	c.JetStream.Stream.applyDefaults(defaults.JetStream.Stream)
+}
+
+func (c *JetStreamStreamConfig) applyDefaults(defaults JetStreamStreamConfig) {
+	if c.Name == "" {
+		c.Name = defaults.Name
+	}
+	if len(c.Subjects) == 0 {
+		c.Subjects = defaults.Subjects
+	}
+	if c.Storage == "" {
+		c.Storage = defaults.Storage
+	}
+	if c.MaxAge == 0 {
+		c.MaxAge = defaults.MaxAge
+	}
+	if c.MaxBytes == 0 {
+		c.MaxBytes = defaults.MaxBytes
+	}
+	if c.Replicas == 0 {
+		c.Replicas = defaults.Replicas
+	}
+	if c.Retention == "" {
+		c.Retention = defaults.Retention
+	}
+	if c.Discard == "" {
+		c.Discard = defaults.Discard
+	}
+}
+
+func (c JetStreamStreamConfig) NATSConfig() (*nats.StreamConfig, error) {
+	storage, err := parseStoragePolicy(c.Storage)
+	if err != nil {
+		return nil, err
+	}
+	retention, err := parseRetentionPolicy(c.Retention)
+	if err != nil {
+		return nil, err
+	}
+	discard, err := parseDiscardPolicy(c.Discard)
+	if err != nil {
+		return nil, err
+	}
+
+	return &nats.StreamConfig{
+		Name:      c.Name,
+		Subjects:  c.Subjects,
+		Storage:   storage,
+		MaxAge:    c.MaxAge,
+		MaxBytes:  c.MaxBytes,
+		Replicas:  c.Replicas,
+		Retention: retention,
+		Discard:   discard,
+	}, nil
+}
+
+func (c *JetStreamStreamConfig) UnmarshalYAML(value *yaml.Node) error {
+	var raw struct {
+		Name      string   `yaml:"name"`
+		Subjects  []string `yaml:"subjects"`
+		Storage   string   `yaml:"storage"`
+		MaxAge    string   `yaml:"max_age"`
+		MaxBytes  int64    `yaml:"max_bytes"`
+		Replicas  int      `yaml:"replicas"`
+		Retention string   `yaml:"retention"`
+		Discard   string   `yaml:"discard"`
+	}
+	if err := value.Decode(&raw); err != nil {
+		return err
+	}
+
+	*c = JetStreamStreamConfig{
+		Name:      raw.Name,
+		Subjects:  raw.Subjects,
+		Storage:   raw.Storage,
+		MaxBytes:  raw.MaxBytes,
+		Replicas:  raw.Replicas,
+		Retention: raw.Retention,
+		Discard:   raw.Discard,
+	}
+	if raw.MaxAge != "" {
+		duration, err := time.ParseDuration(raw.MaxAge)
+		if err != nil {
+			return fmt.Errorf("invalid jetstream.stream.max_age: %w", err)
+		}
+		c.MaxAge = duration
+	}
+	return nil
+}
+
+func parseStoragePolicy(value string) (nats.StorageType, error) {
+	switch value {
+	case "", "file":
+		return nats.FileStorage, nil
+	case "memory":
+		return nats.MemoryStorage, nil
+	default:
+		return nats.FileStorage, fmt.Errorf("unsupported JetStream storage policy: %s", value)
+	}
+}
+
+func parseRetentionPolicy(value string) (nats.RetentionPolicy, error) {
+	switch value {
+	case "", "limits":
+		return nats.LimitsPolicy, nil
+	case "interest":
+		return nats.InterestPolicy, nil
+	case "workqueue":
+		return nats.WorkQueuePolicy, nil
+	default:
+		return nats.LimitsPolicy, fmt.Errorf("unsupported JetStream retention policy: %s", value)
+	}
+}
+
+func parseDiscardPolicy(value string) (nats.DiscardPolicy, error) {
+	switch value {
+	case "", "old":
+		return nats.DiscardOld, nil
+	case "new":
+		return nats.DiscardNew, nil
+	default:
+		return nats.DiscardOld, fmt.Errorf("unsupported JetStream discard policy: %s", value)
+	}
+}

--- a/internal/core/config_test.go
+++ b/internal/core/config_test.go
@@ -1,0 +1,133 @@
+package core
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/nats-io/nats.go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDefaultCoreConfig_JetStreamPolicy(t *testing.T) {
+	cfg := DefaultCoreConfig()
+
+	assert.Equal(t, "PLATFORM_DATA", cfg.JetStream.Stream.Name)
+	assert.Equal(t, []string{"platform.data.>"}, cfg.JetStream.Stream.Subjects)
+	assert.Equal(t, "file", cfg.JetStream.Stream.Storage)
+	assert.Equal(t, 7*24*time.Hour, cfg.JetStream.Stream.MaxAge)
+	assert.Equal(t, int64(1024*1024*1024), cfg.JetStream.Stream.MaxBytes)
+	assert.Equal(t, 1, cfg.JetStream.Stream.Replicas)
+	assert.Equal(t, "limits", cfg.JetStream.Stream.Retention)
+	assert.Equal(t, "old", cfg.JetStream.Stream.Discard)
+	assert.Equal(t, "embedded", cfg.Storage.MigrationsDir)
+	assert.True(t, cfg.Storage.AutoMigrate)
+}
+
+func TestLoadCoreConfig_JetStreamPolicyFromYAML(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	err := os.WriteFile(path, []byte(`
+nats:
+  port: 4333
+  http_port: 8333
+  store_dir: /tmp/jetstream
+storage:
+  metadata_db: /tmp/metadata.db
+  data_dir: /tmp/data
+  migrations_dir: embedded
+  auto_migrate: false
+templates:
+  dir: /tmp/templates
+jetstream:
+  stream:
+    name: TEST_DATA
+    subjects:
+      - custom.data.>
+    storage: memory
+    max_age: 1h
+    max_bytes: 1048576
+    replicas: 1
+    retention: limits
+    discard: new
+  dead_letter_subject: custom.data.deadletter
+`), 0644)
+	require.NoError(t, err)
+
+	cfg, err := LoadCoreConfig(path)
+	require.NoError(t, err)
+
+	assert.Equal(t, 4333, cfg.NATS.Port)
+	assert.Equal(t, 8333, cfg.NATS.HTTPPort)
+	assert.Equal(t, "/tmp/jetstream", cfg.NATS.StoreDir)
+	assert.Equal(t, "/tmp/metadata.db", cfg.Storage.MetadataDB)
+	assert.Equal(t, "embedded", cfg.Storage.MigrationsDir)
+	assert.False(t, cfg.Storage.AutoMigrate)
+	assert.Equal(t, "/tmp/templates", cfg.Templates.Dir)
+	assert.Equal(t, "TEST_DATA", cfg.JetStream.Stream.Name)
+	assert.Equal(t, []string{"custom.data.>"}, cfg.JetStream.Stream.Subjects)
+	assert.Equal(t, time.Hour, cfg.JetStream.Stream.MaxAge)
+	assert.Equal(t, int64(1048576), cfg.JetStream.Stream.MaxBytes)
+	assert.Equal(t, "custom.data.deadletter", cfg.JetStream.DeadLetterSubject)
+
+	streamConfig, err := cfg.JetStream.Stream.NATSConfig()
+	require.NoError(t, err)
+	assert.Equal(t, nats.MemoryStorage, streamConfig.Storage)
+	assert.Equal(t, nats.DiscardNew, streamConfig.Discard)
+	assert.Equal(t, nats.LimitsPolicy, streamConfig.Retention)
+}
+
+func TestJetStreamStreamConfig_NATSConfigRejectsInvalidPolicies(t *testing.T) {
+	tests := []struct {
+		name   string
+		config JetStreamStreamConfig
+	}{
+		{
+			name: "storage",
+			config: JetStreamStreamConfig{
+				Name:      "TEST",
+				Subjects:  []string{"test.>"},
+				Storage:   "disk",
+				MaxAge:    time.Hour,
+				MaxBytes:  1024,
+				Replicas:  1,
+				Retention: "limits",
+				Discard:   "old",
+			},
+		},
+		{
+			name: "retention",
+			config: JetStreamStreamConfig{
+				Name:      "TEST",
+				Subjects:  []string{"test.>"},
+				Storage:   "file",
+				MaxAge:    time.Hour,
+				MaxBytes:  1024,
+				Replicas:  1,
+				Retention: "forever",
+				Discard:   "old",
+			},
+		},
+		{
+			name: "discard",
+			config: JetStreamStreamConfig{
+				Name:      "TEST",
+				Subjects:  []string{"test.>"},
+				Storage:   "file",
+				MaxAge:    time.Hour,
+				MaxBytes:  1024,
+				Replicas:  1,
+				Retention: "limits",
+				Discard:   "middle",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := tt.config.NATSConfig()
+			require.Error(t, err)
+		})
+	}
+}

--- a/internal/core/handler.go
+++ b/internal/core/handler.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"encoding/json"
+	"expvar"
 	"log"
 	"sync"
 	"time"
@@ -11,18 +12,48 @@ import (
 
 // DataHandler handles NATS messages for asset data
 type DataHandler struct {
-	mu    sync.Mutex
-	data  []AssetData           // in-memory storage (PoC)
-	store *Store                // for auto-registration
-	js    nats.JetStreamContext // for publishing to JetStream
+	mu                sync.Mutex
+	data              []AssetData           // in-memory storage (PoC)
+	store             *Store                // for auto-registration
+	js                nats.JetStreamContext // for publishing to JetStream
+	validatedSubject  string
+	deadLetterSubject string
+}
+
+var (
+	jetStreamPublishFailures = expvar.NewInt("edg_core_jetstream_publish_failures")
+	jetStreamDeadLetters     = expvar.NewInt("edg_core_jetstream_dead_letters")
+	jetStreamDeadLetterFails = expvar.NewInt("edg_core_jetstream_dead_letter_failures")
+)
+
+// DeadLetterMessage records a failed core-to-JetStream publish attempt.
+type DeadLetterMessage struct {
+	OriginalSubject string          `json:"original_subject"`
+	TargetSubject   string          `json:"target_subject"`
+	Error           string          `json:"error"`
+	Payload         json.RawMessage `json:"payload"`
+	Timestamp       time.Time       `json:"timestamp"`
 }
 
 func NewDataHandler(js nats.JetStreamContext, store *Store) *DataHandler {
 	return &DataHandler{
-		data:  make([]AssetData, 0),
-		store: store,
-		js:    js,
+		data:              make([]AssetData, 0),
+		store:             store,
+		js:                js,
+		validatedSubject:  DefaultValidatedDataSubject,
+		deadLetterSubject: DefaultDeadLetterSubject,
 	}
+}
+
+func NewDataHandlerWithSubjects(js nats.JetStreamContext, store *Store, validatedSubject, deadLetterSubject string) *DataHandler {
+	handler := NewDataHandler(js, store)
+	if validatedSubject != "" {
+		handler.validatedSubject = validatedSubject
+	}
+	if deadLetterSubject != "" {
+		handler.deadLetterSubject = deadLetterSubject
+	}
+	return handler
 }
 
 // HandleAssetData processes incoming NATS messages
@@ -56,8 +87,10 @@ func (h *DataHandler) HandleAssetData(msg *nats.Msg) {
 
 	// Publish validated data to JetStream for persistence
 	if h.js != nil {
-		if _, err := h.js.Publish("platform.data.validated", msg.Data); err != nil {
+		if _, err := h.js.Publish(h.validatedSubject, msg.Data); err != nil {
+			jetStreamPublishFailures.Add(1)
 			log.Printf("[Core] Failed to publish to JetStream: %v", err)
+			h.publishDeadLetter(msg, err)
 		}
 	}
 
@@ -73,6 +106,32 @@ func (h *DataHandler) HandleAssetData(msg *nats.Msg) {
 			log.Printf("       ├─ %s = %v [%s]", v.Name, *v.Flag, v.Quality)
 		}
 	}
+}
+
+func (h *DataHandler) publishDeadLetter(msg *nats.Msg, publishErr error) {
+	if h.deadLetterSubject == "" {
+		return
+	}
+
+	envelope := DeadLetterMessage{
+		OriginalSubject: msg.Subject,
+		TargetSubject:   h.validatedSubject,
+		Error:           publishErr.Error(),
+		Payload:         append(json.RawMessage(nil), msg.Data...),
+		Timestamp:       time.Now().UTC(),
+	}
+	data, err := json.Marshal(envelope)
+	if err != nil {
+		jetStreamDeadLetterFails.Add(1)
+		log.Printf("[Core] Failed to encode dead-letter message: %v", err)
+		return
+	}
+	if _, err := h.js.Publish(h.deadLetterSubject, data); err != nil {
+		jetStreamDeadLetterFails.Add(1)
+		log.Printf("[Core] Failed to publish dead-letter message: %v", err)
+		return
+	}
+	jetStreamDeadLetters.Add(1)
 }
 
 // GetDataCount returns the number of stored data entries

--- a/internal/core/handler_jetstream_test.go
+++ b/internal/core/handler_jetstream_test.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"encoding/json"
+	"expvar"
 	"testing"
 	"time"
 
@@ -253,4 +254,50 @@ func TestHandleAssetData_JetStreamPublishError(t *testing.T) {
 
 	// Data should still be stored in memory
 	assert.Equal(t, 1, handler.GetDataCount())
+}
+
+func TestHandleAssetData_PublishErrorDeadLettersMessage(t *testing.T) {
+	_, _, js := startTestNATSServer(t, true)
+
+	_, err := js.AddStream(&nats.StreamConfig{
+		Name:     "DLQ_STREAM",
+		Subjects: []string{"platform.data.deadletter"},
+		Storage:  nats.MemoryStorage,
+	})
+	require.NoError(t, err)
+
+	handler := NewDataHandler(js, nil)
+	beforePublishFailures := expvar.Get("edg_core_jetstream_publish_failures").(*expvar.Int).Value()
+	beforeDeadLetters := expvar.Get("edg_core_jetstream_dead_letters").(*expvar.Int).Value()
+
+	data := &AssetData{
+		AssetID:   "sensor-001",
+		Timestamp: 1234567890,
+		Values:    []TagValue{{Name: "temp", Number: new(float64)}},
+	}
+
+	jsonData, err := json.Marshal(data)
+	require.NoError(t, err)
+
+	handler.HandleAssetData(&nats.Msg{
+		Subject: "platform.data.asset",
+		Data:    jsonData,
+	})
+
+	assert.Equal(t, beforePublishFailures+1, expvar.Get("edg_core_jetstream_publish_failures").(*expvar.Int).Value())
+	assert.Equal(t, beforeDeadLetters+1, expvar.Get("edg_core_jetstream_dead_letters").(*expvar.Int).Value())
+
+	sub, err := js.PullSubscribe("platform.data.deadletter", "deadletter-audit")
+	require.NoError(t, err)
+	defer sub.Unsubscribe()
+
+	msgs, err := sub.Fetch(1, nats.MaxWait(2*time.Second))
+	require.NoError(t, err)
+	require.Len(t, msgs, 1)
+
+	var envelope DeadLetterMessage
+	require.NoError(t, json.Unmarshal(msgs[0].Data, &envelope))
+	assert.Equal(t, "platform.data.asset", envelope.OriginalSubject)
+	assert.Equal(t, "platform.data.validated", envelope.TargetSubject)
+	assert.JSONEq(t, string(jsonData), string(envelope.Payload))
 }

--- a/internal/core/handler_test.go
+++ b/internal/core/handler_test.go
@@ -93,6 +93,18 @@ func TestHandleAssetData_AutoRegister(t *testing.T) {
 	assert.False(t, asset.UpdatedAt.IsZero())
 }
 
+func TestNewDataHandlerWithSubjects(t *testing.T) {
+	handler := NewDataHandlerWithSubjects(nil, nil, "custom.validated", "custom.deadletter")
+
+	require.NotNil(t, handler)
+	assert.Equal(t, "custom.validated", handler.validatedSubject)
+	assert.Equal(t, "custom.deadletter", handler.deadLetterSubject)
+
+	defaults := NewDataHandlerWithSubjects(nil, nil, "", "")
+	assert.Equal(t, DefaultValidatedDataSubject, defaults.validatedSubject)
+	assert.Equal(t, DefaultDeadLetterSubject, defaults.deadLetterSubject)
+}
+
 // TestGetDataCount tests thread-safe data count
 func TestGetDataCount(t *testing.T) {
 	handler := NewDataHandler(nil, nil)

--- a/internal/core/store.go
+++ b/internal/core/store.go
@@ -18,6 +18,11 @@ type Store struct {
 
 // NewStore creates and initializes a new Store
 func NewStore(dbPath string) (*Store, error) {
+	return NewStoreWithMigrations(dbPath, true)
+}
+
+// NewStoreWithMigrations creates a Store and optionally applies embedded migrations.
+func NewStoreWithMigrations(dbPath string, autoMigrate bool) (*Store, error) {
 	// Create data directory if not exists
 	dir := filepath.Dir(dbPath)
 	if err := os.MkdirAll(dir, 0755); err != nil {
@@ -39,12 +44,44 @@ func NewStore(dbPath string) (*Store, error) {
 	}
 
 	store := &Store{db: db}
-	if err := runMigrations(db); err != nil {
-		db.Close()
-		return nil, fmt.Errorf("failed to initialize DB: %w", err)
+	if autoMigrate {
+		if err := runMigrations(db); err != nil {
+			db.Close()
+			return nil, fmt.Errorf("failed to initialize DB: %w", err)
+		}
+	}
+
+	if !autoMigrate {
+		if err := verifyStoreSchema(db); err != nil {
+			db.Close()
+			return nil, fmt.Errorf("failed to verify DB schema: %w", err)
+		}
 	}
 
 	return store, nil
+}
+
+func verifyStoreSchema(db *sql.DB) error {
+	var count int
+	if err := db.QueryRow(
+		`SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = 'assets'`,
+	).Scan(&count); err != nil {
+		return err
+	}
+	if count == 0 {
+		return fmt.Errorf("assets table not found; run migrations or enable auto_migrate")
+	}
+
+	if err := db.QueryRow(
+		`SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = 'asset_relations'`,
+	).Scan(&count); err != nil {
+		return err
+	}
+	if count == 0 {
+		return fmt.Errorf("asset_relations table not found; run migrations or enable auto_migrate")
+	}
+
+	return nil
 }
 
 // Close closes the DB connection

--- a/internal/core/store_test.go
+++ b/internal/core/store_test.go
@@ -1,6 +1,7 @@
 package core
 
 import (
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -16,6 +17,29 @@ func TestNewStore_Success(t *testing.T) {
 	defer store.Close()
 
 	// Verify DB is initialized by checking stats
+	stats, err := store.GetStats()
+	require.NoError(t, err)
+	assert.Equal(t, 0, stats.TotalAssets)
+}
+
+func TestNewStoreWithMigrationsDisabledRequiresExistingSchema(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "metadata.db")
+
+	store, err := NewStoreWithMigrations(dbPath, false)
+
+	require.Error(t, err)
+	assert.Nil(t, store)
+	assert.Contains(t, err.Error(), "run migrations or enable auto_migrate")
+}
+
+func TestNewStoreWithMigrationsDisabledOpensMigratedDB(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "metadata.db")
+	require.NoError(t, RunMigrations(dbPath))
+
+	store, err := NewStoreWithMigrations(dbPath, false)
+	require.NoError(t, err)
+	defer store.Close()
+
 	stats, err := store.GetStats()
 	require.NoError(t, err)
 	assert.Equal(t, 0, stats.TotalAssets)


### PR DESCRIPTION
## Summary
- Documents the data-plane reliability boundary in ADR 0001.
- Moves JetStream stream policy into core config defaults and environment YAML.
- Adds dead-letter fallback and counters for JetStream publish failures.
- Adds Go-only chaos coverage for backlog recovery, discard-old pressure, auto-registration races, and dead-letter behavior.

## Validation
- go test ./internal/core -run 'TestDefaultCoreConfig|TestLoadCoreConfig|TestHandleAssetData_PublishErrorDeadLettersMessage|TestChaos' -v
- go test ./...
- go vet ./...
- go test ./... -race
- go test ./... -race -coverprofile=coverage.out
- go run honnef.co/go/tools/cmd/staticcheck@latest ./...

Closes #65
