### PR TITLE
feat: publish metadata change events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Asset metadata extensions for external IDs, source tracking, attributes, and update timestamps
 - SQLite metadata schema migrations with embedded migration files
 - Asset update metadata API subject (`platform.meta.asset.update`)
+- Metadata change events for asset and relation create/update/delete notifications
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@
 ## Key Features
 
 *   **Automatic Asset Registration**: Device discovery and metadata registration without manual configuration.
+*   **Metadata Change Events**: Publishes asset and relation changes on NATS for adapters and sidecars.
 *   **Data Validation**: Enforces schema and quality checks at the edge before data enters your storage.
 *   **At-Least-Once Delivery**: Uses NATS JetStream for durable delivery after core publish acknowledgement. See [ADR 0001](docs/adr/0001-data-plane-reliability.md) for the exact reliability boundary.
 *   **Flexible Adapters**: Easily write collectors in Python for Modbus, OPC-UA, or custom protocols.

--- a/cmd/core/main.go
+++ b/cmd/core/main.go
@@ -132,13 +132,15 @@ func main() {
 	log.Printf("[Core] Loaded %d templates", loader.Count())
 
 	// 6. Create handlers and subscribe
+	eventPublisher := core.NewEventPublisher(nc)
 	dataHandler := core.NewDataHandlerWithSubjects(
 		js,
 		store,
 		cfg.JetStream.ValidatedSubject,
 		cfg.JetStream.DeadLetterSubject,
+		eventPublisher,
 	)
-	metaHandler := core.NewMetaHandler(store, loader)
+	metaHandler := core.NewMetaHandler(store, loader, eventPublisher)
 
 	_, err = nc.Subscribe("platform.data.asset", dataHandler.HandleAssetData)
 	if err != nil {

--- a/docs/ADAPTER_GUIDE.md
+++ b/docs/ADAPTER_GUIDE.md
@@ -25,3 +25,11 @@ Store external identifiers in `external_ids` as string key/value pairs. Common k
 ## Attributes
 
 Use `attributes` for adapter-specific metadata that does not need indexed querying yet. Keep values as strings and avoid embedding large nested JSON payloads.
+
+## Metadata Change Events
+
+Subscribe to `platform.meta.*.changed` to react to asset and relation metadata changes. EDG Core publishes these events after successful store mutations only; failed create, update, or delete requests do not emit events.
+
+Events are best-effort plain NATS messages. On adapter startup, first request the current asset list through `platform.meta.asset.list`, then apply `platform.meta.asset.changed` and `platform.meta.relation.changed` events for incremental updates.
+
+See [Metadata Events](events.md) for the payload schema and examples.

--- a/docs/events.md
+++ b/docs/events.md
@@ -1,0 +1,78 @@
+# EDG Metadata Events
+
+EDG Core publishes best-effort NATS events after metadata mutations are stored.
+Subscribers should use these events as change notifications and reconcile current
+state with metadata request subjects when they start.
+
+## Subjects
+
+| Subject | Entity | When |
+| --- | --- | --- |
+| `platform.meta.asset.changed` | Asset | Asset create, update, delete, and data-plane auto-registration |
+| `platform.meta.relation.changed` | Asset relation | Relation create and delete |
+
+These are plain NATS publishes, not JetStream writes. A subscriber that is not
+connected can miss events.
+
+## Payload
+
+```json
+{
+  "schema_version": 1,
+  "event_type": "created",
+  "entity_type": "asset",
+  "entity_id": "sensor-001",
+  "source": "auto",
+  "timestamp": "2026-05-07T12:34:56Z",
+  "after": {
+    "id": "sensor-001",
+    "name": "sensor-001",
+    "source": "auto",
+    "created_at": "2026-05-07T12:34:56Z",
+    "updated_at": "2026-05-07T12:34:56Z"
+  }
+}
+```
+
+Fields:
+
+- `schema_version`: event schema version. Current value is `1`.
+- `event_type`: `created`, `updated`, or `deleted`.
+- `entity_type`: `asset` or `relation`.
+- `entity_id`: asset ID or relation ID.
+- `source`: system that caused the change. Use `manual`, `auto`, or a stable adapter name.
+- `timestamp`: publish timestamp from EDG Core.
+- `before`: previous full object snapshot. Omitted for creates.
+- `after`: new full object snapshot. Omitted for deletes.
+
+## Subscribe
+
+```bash
+nats sub "platform.meta.*.changed"
+```
+
+Python:
+
+```python
+import asyncio
+import json
+import nats
+
+async def main():
+    nc = await nats.connect("nats://localhost:4222")
+
+    async def changed(msg):
+        event = json.loads(msg.data.decode())
+        print(event["entity_type"], event["event_type"], event["entity_id"])
+
+    await nc.subscribe("platform.meta.*.changed", cb=changed)
+    await asyncio.Event().wait()
+
+asyncio.run(main())
+```
+
+## Reconciliation
+
+Events are best-effort notifications. Adapters should request
+`platform.meta.asset.list` during startup, build their local view from that
+response, then subscribe to `platform.meta.*.changed` for incremental updates.

--- a/internal/core/events.go
+++ b/internal/core/events.go
@@ -1,0 +1,90 @@
+package core
+
+import (
+	"encoding/json"
+	"log"
+	"time"
+
+	"github.com/nats-io/nats.go"
+)
+
+const (
+	SubjectAssetChanged    = "platform.meta.asset.changed"
+	SubjectRelationChanged = "platform.meta.relation.changed"
+
+	EventSchemaVersion = 1
+)
+
+type EventType string
+
+const (
+	EventCreated EventType = "created"
+	EventUpdated EventType = "updated"
+	EventDeleted EventType = "deleted"
+)
+
+type EntityType string
+
+const (
+	EntityAsset    EntityType = "asset"
+	EntityRelation EntityType = "relation"
+)
+
+type MetaChangeEvent struct {
+	SchemaVersion int        `json:"schema_version"`
+	EventType     EventType  `json:"event_type"`
+	EntityType    EntityType `json:"entity_type"`
+	EntityID      string     `json:"entity_id"`
+	Source        string     `json:"source"`
+	Timestamp     time.Time  `json:"timestamp"`
+	Before        any        `json:"before,omitempty"`
+	After         any        `json:"after,omitempty"`
+}
+
+type EventPublisher struct {
+	nc *nats.Conn
+}
+
+func NewEventPublisher(nc *nats.Conn) *EventPublisher {
+	return &EventPublisher{nc: nc}
+}
+
+func (p *EventPublisher) PublishAssetChanged(ev MetaChangeEvent) {
+	p.publishMetaChange(SubjectAssetChanged, normalizeMetaChangeEvent(ev, EntityAsset))
+}
+
+func (p *EventPublisher) PublishRelationChanged(ev MetaChangeEvent) {
+	p.publishMetaChange(SubjectRelationChanged, normalizeMetaChangeEvent(ev, EntityRelation))
+}
+
+func (p *EventPublisher) publishMetaChange(subject string, ev MetaChangeEvent) {
+	if p == nil || p.nc == nil {
+		return
+	}
+
+	data, err := json.Marshal(ev)
+	if err != nil {
+		log.Printf("[Meta] Failed to marshal metadata change event: %v", err)
+		return
+	}
+
+	if err := p.nc.Publish(subject, data); err != nil {
+		log.Printf("[Meta] Failed to publish metadata change event to %s: %v", subject, err)
+	}
+}
+
+func normalizeMetaChangeEvent(ev MetaChangeEvent, entityType EntityType) MetaChangeEvent {
+	if ev.SchemaVersion == 0 {
+		ev.SchemaVersion = EventSchemaVersion
+	}
+	if ev.EntityType == "" {
+		ev.EntityType = entityType
+	}
+	if ev.Source == "" {
+		ev.Source = SourceManual
+	}
+	if ev.Timestamp.IsZero() {
+		ev.Timestamp = time.Now()
+	}
+	return ev
+}

--- a/internal/core/events_test.go
+++ b/internal/core/events_test.go
@@ -1,0 +1,107 @@
+package core
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/nats-io/nats.go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMetaChangeEvent_JSONSerialization(t *testing.T) {
+	now := time.Now().UTC()
+	ev := MetaChangeEvent{
+		SchemaVersion: EventSchemaVersion,
+		EventType:     EventUpdated,
+		EntityType:    EntityAsset,
+		EntityID:      "asset-001",
+		Source:        "aas",
+		Timestamp:     now,
+		Before:        &Asset{ID: "asset-001", Name: "old", Source: SourceManual},
+		After:         &Asset{ID: "asset-001", Name: "new", Source: "aas"},
+	}
+
+	data, err := json.Marshal(ev)
+	require.NoError(t, err)
+
+	var decoded struct {
+		SchemaVersion int             `json:"schema_version"`
+		EventType     EventType       `json:"event_type"`
+		EntityType    EntityType      `json:"entity_type"`
+		EntityID      string          `json:"entity_id"`
+		Source        string          `json:"source"`
+		Timestamp     time.Time       `json:"timestamp"`
+		Before        json.RawMessage `json:"before"`
+		After         json.RawMessage `json:"after"`
+	}
+	require.NoError(t, json.Unmarshal(data, &decoded))
+
+	assert.Equal(t, EventSchemaVersion, decoded.SchemaVersion)
+	assert.Equal(t, EventUpdated, decoded.EventType)
+	assert.Equal(t, EntityAsset, decoded.EntityType)
+	assert.Equal(t, "asset-001", decoded.EntityID)
+	assert.Equal(t, "aas", decoded.Source)
+	assert.Equal(t, now, decoded.Timestamp)
+	assert.NotEmpty(t, decoded.Before)
+	assert.NotEmpty(t, decoded.After)
+}
+
+func TestMetaChangeEvent_OmitsNilBeforeAfter(t *testing.T) {
+	ev := MetaChangeEvent{
+		SchemaVersion: EventSchemaVersion,
+		EventType:     EventCreated,
+		EntityType:    EntityRelation,
+		EntityID:      "rel-001",
+		Source:        SourceManual,
+		Timestamp:     time.Now(),
+	}
+
+	data, err := json.Marshal(ev)
+	require.NoError(t, err)
+
+	var decoded map[string]any
+	require.NoError(t, json.Unmarshal(data, &decoded))
+	assert.NotContains(t, decoded, "before")
+	assert.NotContains(t, decoded, "after")
+}
+
+func TestEventPublisher_NormalizesAndPublishes(t *testing.T) {
+	_, nc, _ := startTestNATSServer(t, false)
+
+	received := make(chan *MetaChangeEvent, 1)
+	sub, err := nc.Subscribe(SubjectAssetChanged, func(msg *nats.Msg) {
+		var ev MetaChangeEvent
+		if err := json.Unmarshal(msg.Data, &ev); err == nil {
+			received <- &ev
+		}
+	})
+	require.NoError(t, err)
+	defer sub.Unsubscribe()
+	require.NoError(t, nc.Flush())
+
+	NewEventPublisher(nc).PublishAssetChanged(MetaChangeEvent{
+		EventType: EventCreated,
+		EntityID:  "asset-001",
+		After:     &Asset{ID: "asset-001", Name: "sensor"},
+	})
+
+	select {
+	case ev := <-received:
+		assert.Equal(t, EventSchemaVersion, ev.SchemaVersion)
+		assert.Equal(t, EntityAsset, ev.EntityType)
+		assert.Equal(t, SourceManual, ev.Source)
+		assert.False(t, ev.Timestamp.IsZero())
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for metadata event")
+	}
+}
+
+func TestEventPublisher_NilSafe(t *testing.T) {
+	assert.NotPanics(t, func() {
+		NewEventPublisher(nil).PublishAssetChanged(MetaChangeEvent{})
+		var publisher *EventPublisher
+		publisher.PublishRelationChanged(MetaChangeEvent{})
+	})
+}

--- a/internal/core/handler.go
+++ b/internal/core/handler.go
@@ -18,6 +18,7 @@ type DataHandler struct {
 	js                nats.JetStreamContext // for publishing to JetStream
 	validatedSubject  string
 	deadLetterSubject string
+	events            *EventPublisher // for metadata change notifications
 }
 
 var (
@@ -35,18 +36,23 @@ type DeadLetterMessage struct {
 	Timestamp       time.Time       `json:"timestamp"`
 }
 
-func NewDataHandler(js nats.JetStreamContext, store *Store) *DataHandler {
+func NewDataHandler(js nats.JetStreamContext, store *Store, events ...*EventPublisher) *DataHandler {
+	var publisher *EventPublisher
+	if len(events) > 0 {
+		publisher = events[0]
+	}
 	return &DataHandler{
 		data:              make([]AssetData, 0),
 		store:             store,
 		js:                js,
 		validatedSubject:  DefaultValidatedDataSubject,
 		deadLetterSubject: DefaultDeadLetterSubject,
+		events:            publisher,
 	}
 }
 
-func NewDataHandlerWithSubjects(js nats.JetStreamContext, store *Store, validatedSubject, deadLetterSubject string) *DataHandler {
-	handler := NewDataHandler(js, store)
+func NewDataHandlerWithSubjects(js nats.JetStreamContext, store *Store, validatedSubject, deadLetterSubject string, events ...*EventPublisher) *DataHandler {
+	handler := NewDataHandler(js, store, events...)
 	if validatedSubject != "" {
 		handler.validatedSubject = validatedSubject
 	}
@@ -76,6 +82,12 @@ func (h *DataHandler) HandleAssetData(msg *nats.Msg) {
 				UpdatedAt: now,
 			}
 			if err := h.store.CreateAsset(asset); err == nil {
+				h.events.PublishAssetChanged(MetaChangeEvent{
+					EventType: EventCreated,
+					EntityID:  asset.ID,
+					Source:    SourceAuto,
+					After:     asset,
+				})
 				log.Printf("[Core] Auto-registered asset: %s", data.AssetID)
 			}
 		}

--- a/internal/core/handler_test.go
+++ b/internal/core/handler_test.go
@@ -3,6 +3,7 @@ package core
 import (
 	"encoding/json"
 	"testing"
+	"time"
 
 	"github.com/nats-io/nats.go"
 	"github.com/stretchr/testify/assert"
@@ -103,6 +104,90 @@ func TestNewDataHandlerWithSubjects(t *testing.T) {
 	defaults := NewDataHandlerWithSubjects(nil, nil, "", "")
 	assert.Equal(t, DefaultValidatedDataSubject, defaults.validatedSubject)
 	assert.Equal(t, DefaultDeadLetterSubject, defaults.deadLetterSubject)
+}
+
+func TestNewDataHandlerWithSubjectsAndEvents(t *testing.T) {
+	publisher := NewEventPublisher(nil)
+	handler := NewDataHandlerWithSubjects(nil, nil, "custom.validated", "custom.deadletter", publisher)
+
+	require.NotNil(t, handler)
+	assert.Equal(t, "custom.validated", handler.validatedSubject)
+	assert.Equal(t, "custom.deadletter", handler.deadLetterSubject)
+	assert.Same(t, publisher, handler.events)
+}
+
+// TestHandleAssetData_AutoRegisterPublishesChangedEvent tests auto-registration events.
+func TestHandleAssetData_AutoRegisterPublishesChangedEvent(t *testing.T) {
+	_, nc, _ := startTestNATSServer(t, false)
+
+	store, err := NewStore(":memory:")
+	require.NoError(t, err)
+	defer store.Close()
+
+	assetEvents := subscribeMetaEvents(t, nc, SubjectAssetChanged)
+	handler := NewDataHandler(nil, store, NewEventPublisher(nc))
+
+	tempValue := 25.5
+	data := &AssetData{
+		AssetID:   "auto-sensor",
+		Timestamp: time.Now().Unix(),
+		Values: []TagValue{
+			{Name: "temperature", Number: &tempValue},
+		},
+	}
+
+	jsonData, err := json.Marshal(data)
+	require.NoError(t, err)
+
+	handler.HandleAssetData(&nats.Msg{
+		Subject: "platform.data.raw",
+		Data:    jsonData,
+	})
+
+	ev := requireMetaEvent(t, assetEvents)
+	assert.Equal(t, EventCreated, ev.EventType)
+	assert.Equal(t, EntityAsset, ev.EntityType)
+	assert.Equal(t, "auto-sensor", ev.EntityID)
+	assert.Equal(t, SourceAuto, ev.Source)
+	assert.Empty(t, ev.Before)
+	require.NotEmpty(t, ev.After)
+
+	var after Asset
+	require.NoError(t, json.Unmarshal(ev.After, &after))
+	assert.Equal(t, "auto-sensor", after.ID)
+	assert.Equal(t, SourceAuto, after.Source)
+}
+
+// TestHandleAssetData_ExistingAssetDoesNotPublishChangedEvent tests existing asset ingestion.
+func TestHandleAssetData_ExistingAssetDoesNotPublishChangedEvent(t *testing.T) {
+	_, nc, _ := startTestNATSServer(t, false)
+
+	store, err := NewStore(":memory:")
+	require.NoError(t, err)
+	defer store.Close()
+
+	require.NoError(t, store.CreateAsset(&Asset{
+		ID:        "existing-sensor",
+		Name:      "existing-sensor",
+		Source:    SourceManual,
+		CreatedAt: time.Now(),
+	}))
+
+	assetEvents := subscribeMetaEvents(t, nc, SubjectAssetChanged)
+	handler := NewDataHandler(nil, store, NewEventPublisher(nc))
+
+	tempValue := 25.5
+	data := &AssetData{
+		AssetID: "existing-sensor",
+		Values: []TagValue{
+			{Name: "temperature", Number: &tempValue},
+		},
+	}
+	jsonData, err := json.Marshal(data)
+	require.NoError(t, err)
+
+	handler.HandleAssetData(&nats.Msg{Data: jsonData})
+	requireNoMetaEvent(t, assetEvents)
 }
 
 // TestGetDataCount tests thread-safe data count

--- a/internal/core/meta_handler.go
+++ b/internal/core/meta_handler.go
@@ -29,13 +29,19 @@ const (
 type MetaHandler struct {
 	store  *Store
 	loader *TemplateLoader
+	events *EventPublisher
 }
 
 // NewMetaHandler creates a new handler
-func NewMetaHandler(store *Store, loader *TemplateLoader) *MetaHandler {
+func NewMetaHandler(store *Store, loader *TemplateLoader, events ...*EventPublisher) *MetaHandler {
+	var publisher *EventPublisher
+	if len(events) > 0 {
+		publisher = events[0]
+	}
 	return &MetaHandler{
 		store:  store,
 		loader: loader,
+		events: publisher,
 	}
 }
 
@@ -145,6 +151,13 @@ func (h *MetaHandler) handleAssetCreate(msg *nats.Msg) {
 		h.reply(msg, Response{Success: false, Error: err.Error()})
 		return
 	}
+
+	h.events.PublishAssetChanged(MetaChangeEvent{
+		EventType: EventCreated,
+		EntityID:  asset.ID,
+		Source:    asset.Source,
+		After:     asset,
+	})
 
 	log.Printf("[Meta] Asset created: %s (%s)", asset.Name, asset.ID)
 	h.reply(msg, Response{Success: true, Data: asset})
@@ -261,13 +274,22 @@ func (h *MetaHandler) handleAssetUpdate(msg *nats.Msg) {
 		return
 	}
 
+	h.events.PublishAssetChanged(MetaChangeEvent{
+		EventType: EventUpdated,
+		EntityID:  updated.ID,
+		Source:    updated.Source,
+		Before:    existing,
+		After:     updated,
+	})
+
 	log.Printf("[Meta] Asset updated: %s (%s)", updated.Name, updated.ID)
 	h.reply(msg, Response{Success: true, Data: updated})
 }
 
 // DeleteAssetRequest is a request to delete an asset
 type DeleteAssetRequest struct {
-	ID string `json:"id"`
+	ID     string `json:"id"`
+	Source string `json:"source,omitempty"`
 }
 
 func (h *MetaHandler) handleAssetDelete(msg *nats.Msg) {
@@ -282,10 +304,23 @@ func (h *MetaHandler) handleAssetDelete(msg *nats.Msg) {
 		return
 	}
 
+	before, err := h.store.GetAsset(req.ID)
+	if err != nil {
+		h.reply(msg, Response{Success: false, Error: err.Error()})
+		return
+	}
+
 	if err := h.store.DeleteAsset(req.ID); err != nil {
 		h.reply(msg, Response{Success: false, Error: err.Error()})
 		return
 	}
+
+	h.events.PublishAssetChanged(MetaChangeEvent{
+		EventType: EventDeleted,
+		EntityID:  req.ID,
+		Source:    req.Source,
+		Before:    before,
+	})
 
 	log.Printf("[Meta] Asset deleted: %s", req.ID)
 	h.reply(msg, Response{Success: true})
@@ -304,6 +339,7 @@ type CreateRelationRequest struct {
 	TargetAssetID string            `json:"target_asset_id"`
 	RelationType  RelationType      `json:"relation_type"`
 	Metadata      map[string]string `json:"metadata,omitempty"`
+	Source        string            `json:"source,omitempty"`
 }
 
 func (h *MetaHandler) handleRelationCreate(msg *nats.Msg) {
@@ -347,6 +383,13 @@ func (h *MetaHandler) handleRelationCreate(msg *nats.Msg) {
 		h.reply(msg, Response{Success: false, Error: err.Error()})
 		return
 	}
+
+	h.events.PublishRelationChanged(MetaChangeEvent{
+		EventType: EventCreated,
+		EntityID:  relation.ID,
+		Source:    req.Source,
+		After:     relation,
+	})
 
 	log.Printf("[Meta] Relation created: %s (%s -> %s, type: %s)",
 		relation.ID, relation.SourceAssetID, relation.TargetAssetID, relation.RelationType)
@@ -455,7 +498,8 @@ func (h *MetaHandler) handleRelationList(msg *nats.Msg) {
 
 // DeleteRelationRequest is a request to delete a relation
 type DeleteRelationRequest struct {
-	ID string `json:"id"`
+	ID     string `json:"id"`
+	Source string `json:"source,omitempty"`
 }
 
 func (h *MetaHandler) handleRelationDelete(msg *nats.Msg) {
@@ -470,10 +514,23 @@ func (h *MetaHandler) handleRelationDelete(msg *nats.Msg) {
 		return
 	}
 
+	before, err := h.store.GetRelation(req.ID)
+	if err != nil {
+		h.reply(msg, Response{Success: false, Error: err.Error()})
+		return
+	}
+
 	if err := h.store.DeleteRelation(req.ID); err != nil {
 		h.reply(msg, Response{Success: false, Error: err.Error()})
 		return
 	}
+
+	h.events.PublishRelationChanged(MetaChangeEvent{
+		EventType: EventDeleted,
+		EntityID:  req.ID,
+		Source:    req.Source,
+		Before:    before,
+	})
 
 	log.Printf("[Meta] Relation deleted: %s", req.ID)
 	h.reply(msg, Response{Success: true})

--- a/internal/core/meta_handler_test.go
+++ b/internal/core/meta_handler_test.go
@@ -33,6 +33,59 @@ func requestMeta(t *testing.T, nc interface {
 	return resp
 }
 
+type testMetaChangeEvent struct {
+	SchemaVersion int             `json:"schema_version"`
+	EventType     EventType       `json:"event_type"`
+	EntityType    EntityType      `json:"entity_type"`
+	EntityID      string          `json:"entity_id"`
+	Source        string          `json:"source"`
+	Timestamp     time.Time       `json:"timestamp"`
+	Before        json.RawMessage `json:"before,omitempty"`
+	After         json.RawMessage `json:"after,omitempty"`
+}
+
+func subscribeMetaEvents(t *testing.T, nc *nats.Conn, subject string) chan testMetaChangeEvent {
+	t.Helper()
+
+	received := make(chan testMetaChangeEvent, 4)
+	sub, err := nc.Subscribe(subject, func(msg *nats.Msg) {
+		var ev testMetaChangeEvent
+		if err := json.Unmarshal(msg.Data, &ev); err == nil {
+			received <- ev
+		}
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = sub.Unsubscribe()
+	})
+	require.NoError(t, nc.Flush())
+	return received
+}
+
+func requireMetaEvent(t *testing.T, received <-chan testMetaChangeEvent) testMetaChangeEvent {
+	t.Helper()
+
+	select {
+	case ev := <-received:
+		require.Equal(t, EventSchemaVersion, ev.SchemaVersion)
+		require.False(t, ev.Timestamp.IsZero())
+		return ev
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for metadata change event")
+		return testMetaChangeEvent{}
+	}
+}
+
+func requireNoMetaEvent(t *testing.T, received <-chan testMetaChangeEvent) {
+	t.Helper()
+
+	select {
+	case ev := <-received:
+		t.Fatalf("unexpected metadata change event: %+v", ev)
+	case <-time.After(150 * time.Millisecond):
+	}
+}
+
 // TestMetaHandler_CreateAsset tests asset creation through handler
 func TestMetaHandler_CreateAsset(t *testing.T) {
 	store, err := NewStore(":memory:")
@@ -228,7 +281,8 @@ func TestMetaHandler_CreateAssetExtendedMetadata(t *testing.T) {
 	require.NoError(t, err)
 	defer store.Close()
 
-	handler := NewMetaHandler(store, NewTemplateLoader())
+	assetEvents := subscribeMetaEvents(t, nc, SubjectAssetChanged)
+	handler := NewMetaHandler(store, NewTemplateLoader(), NewEventPublisher(nc))
 	require.NoError(t, handler.RegisterHandlers(nc))
 	require.NoError(t, nc.Flush())
 
@@ -249,6 +303,19 @@ func TestMetaHandler_CreateAssetExtendedMetadata(t *testing.T) {
 	assert.Equal(t, "aas", asset.Source)
 	assert.Equal(t, map[string]string{"manufacturer": "ACME"}, asset.Attributes)
 	assert.False(t, asset.UpdatedAt.IsZero())
+
+	ev := requireMetaEvent(t, assetEvents)
+	assert.Equal(t, EventCreated, ev.EventType)
+	assert.Equal(t, EntityAsset, ev.EntityType)
+	assert.Equal(t, asset.ID, ev.EntityID)
+	assert.Equal(t, "aas", ev.Source)
+	assert.Empty(t, ev.Before)
+	require.NotEmpty(t, ev.After)
+
+	var after Asset
+	require.NoError(t, json.Unmarshal(ev.After, &after))
+	assert.Equal(t, asset.ID, after.ID)
+	assert.Equal(t, "extended-create", after.Name)
 }
 
 // TestMetaHandler_UpdateAsset tests full asset metadata replacement through NATS.
@@ -272,7 +339,8 @@ func TestMetaHandler_UpdateAsset(t *testing.T) {
 		UpdatedAt:    createdAt,
 	}))
 
-	handler := NewMetaHandler(store, NewTemplateLoader())
+	assetEvents := subscribeMetaEvents(t, nc, SubjectAssetChanged)
+	handler := NewMetaHandler(store, NewTemplateLoader(), NewEventPublisher(nc))
 	require.NoError(t, handler.RegisterHandlers(nc))
 	require.NoError(t, nc.Flush())
 
@@ -295,6 +363,24 @@ func TestMetaHandler_UpdateAsset(t *testing.T) {
 	assert.Equal(t, "aas", asset.Source)
 	assert.Equal(t, map[string]string{"status": "new"}, asset.Attributes)
 	assert.True(t, asset.UpdatedAt.After(createdAt))
+
+	ev := requireMetaEvent(t, assetEvents)
+	assert.Equal(t, EventUpdated, ev.EventType)
+	assert.Equal(t, EntityAsset, ev.EntityType)
+	assert.Equal(t, "asset-update", ev.EntityID)
+	assert.Equal(t, "aas", ev.Source)
+	require.NotEmpty(t, ev.Before)
+	require.NotEmpty(t, ev.After)
+
+	var before Asset
+	require.NoError(t, json.Unmarshal(ev.Before, &before))
+	assert.Equal(t, "old-name", before.Name)
+	assert.Equal(t, SourceManual, before.Source)
+
+	var after Asset
+	require.NoError(t, json.Unmarshal(ev.After, &after))
+	assert.Equal(t, "new-name", after.Name)
+	assert.Equal(t, "aas", after.Source)
 }
 
 // TestMetaHandler_UpdateAssetNotFound tests update failure for missing assets.
@@ -339,6 +425,70 @@ func TestMetaHandler_UpdateAssetInvalidPayload(t *testing.T) {
 	assert.Equal(t, "invalid request format", resp.Error)
 }
 
+// TestMetaHandler_DeleteAssetPublishesChangedEvent tests deletion events.
+func TestMetaHandler_DeleteAssetPublishesChangedEvent(t *testing.T) {
+	_, nc, _ := startTestNATSServer(t, false)
+
+	store, err := NewStore(":memory:")
+	require.NoError(t, err)
+	defer store.Close()
+
+	require.NoError(t, store.CreateAsset(&Asset{
+		ID:        "asset-delete",
+		Name:      "delete-me",
+		Source:    "opcua",
+		CreatedAt: time.Now(),
+	}))
+
+	assetEvents := subscribeMetaEvents(t, nc, SubjectAssetChanged)
+	handler := NewMetaHandler(store, NewTemplateLoader(), NewEventPublisher(nc))
+	require.NoError(t, handler.RegisterHandlers(nc))
+	require.NoError(t, nc.Flush())
+
+	resp := requestMeta(t, nc, SubjectAssetDelete, DeleteAssetRequest{
+		ID:     "asset-delete",
+		Source: "operator",
+	})
+	require.True(t, resp.Success, resp.Error)
+
+	ev := requireMetaEvent(t, assetEvents)
+	assert.Equal(t, EventDeleted, ev.EventType)
+	assert.Equal(t, EntityAsset, ev.EntityType)
+	assert.Equal(t, "asset-delete", ev.EntityID)
+	assert.Equal(t, "operator", ev.Source)
+	require.NotEmpty(t, ev.Before)
+	assert.Empty(t, ev.After)
+
+	var before Asset
+	require.NoError(t, json.Unmarshal(ev.Before, &before))
+	assert.Equal(t, "delete-me", before.Name)
+	assert.Equal(t, "opcua", before.Source)
+}
+
+// TestMetaHandler_AssetCreateFailureDoesNotPublishChangedEvent verifies store failures are silent.
+func TestMetaHandler_AssetCreateFailureDoesNotPublishChangedEvent(t *testing.T) {
+	_, nc, _ := startTestNATSServer(t, false)
+
+	store, err := NewStore(":memory:")
+	require.NoError(t, err)
+	defer store.Close()
+
+	require.NoError(t, store.CreateAsset(&Asset{
+		ID:        "existing",
+		Name:      "duplicate",
+		CreatedAt: time.Now(),
+	}))
+
+	assetEvents := subscribeMetaEvents(t, nc, SubjectAssetChanged)
+	handler := NewMetaHandler(store, NewTemplateLoader(), NewEventPublisher(nc))
+	require.NoError(t, handler.RegisterHandlers(nc))
+	require.NoError(t, nc.Flush())
+
+	resp := requestMeta(t, nc, SubjectAssetCreate, CreateAssetRequest{Name: "duplicate"})
+	assert.False(t, resp.Success)
+	requireNoMetaEvent(t, assetEvents)
+}
+
 // ==================== AssetRelation Handler Tests ====================
 
 // TestHandleRelationCreate_Success tests successful relation creation
@@ -377,6 +527,67 @@ func TestHandleRelationCreate_Success(t *testing.T) {
 	assert.Equal(t, "rel-001", retrieved.ID)
 	assert.Equal(t, "asset-001", retrieved.SourceAssetID)
 	assert.Equal(t, "asset-002", retrieved.TargetAssetID)
+}
+
+// TestHandleRelationCreateAndDelete_PublishChangedEvents tests relation event payloads.
+func TestHandleRelationCreateAndDelete_PublishChangedEvents(t *testing.T) {
+	_, nc, _ := startTestNATSServer(t, false)
+
+	store, err := NewStore(":memory:")
+	require.NoError(t, err)
+	defer store.Close()
+
+	require.NoError(t, store.CreateAsset(&Asset{ID: "asset-001", Name: "sensor-1", CreatedAt: time.Now()}))
+	require.NoError(t, store.CreateAsset(&Asset{ID: "asset-002", Name: "equipment-1", CreatedAt: time.Now()}))
+
+	relationEvents := subscribeMetaEvents(t, nc, SubjectRelationChanged)
+	handler := NewMetaHandler(store, NewTemplateLoader(), NewEventPublisher(nc))
+	require.NoError(t, handler.RegisterHandlers(nc))
+	require.NoError(t, nc.Flush())
+
+	resp := requestMeta(t, nc, SubjectRelationCreate, CreateRelationRequest{
+		SourceAssetID: "asset-001",
+		TargetAssetID: "asset-002",
+		RelationType:  RelationPartOf,
+		Metadata:      map[string]string{"installed_date": "2025-01-15"},
+		Source:        "aas",
+	})
+	require.True(t, resp.Success, resp.Error)
+
+	var relation AssetRelation
+	require.NoError(t, json.Unmarshal(resp.Data, &relation))
+
+	created := requireMetaEvent(t, relationEvents)
+	assert.Equal(t, EventCreated, created.EventType)
+	assert.Equal(t, EntityRelation, created.EntityType)
+	assert.Equal(t, relation.ID, created.EntityID)
+	assert.Equal(t, "aas", created.Source)
+	assert.Empty(t, created.Before)
+	require.NotEmpty(t, created.After)
+
+	var createdAfter AssetRelation
+	require.NoError(t, json.Unmarshal(created.After, &createdAfter))
+	assert.Equal(t, relation.ID, createdAfter.ID)
+	assert.Equal(t, RelationPartOf, createdAfter.RelationType)
+
+	resp = requestMeta(t, nc, SubjectRelationDelete, DeleteRelationRequest{
+		ID:     relation.ID,
+		Source: "operator",
+	})
+	require.True(t, resp.Success, resp.Error)
+
+	deleted := requireMetaEvent(t, relationEvents)
+	assert.Equal(t, EventDeleted, deleted.EventType)
+	assert.Equal(t, EntityRelation, deleted.EntityType)
+	assert.Equal(t, relation.ID, deleted.EntityID)
+	assert.Equal(t, "operator", deleted.Source)
+	require.NotEmpty(t, deleted.Before)
+	assert.Empty(t, deleted.After)
+
+	var deletedBefore AssetRelation
+	require.NoError(t, json.Unmarshal(deleted.Before, &deletedBefore))
+	assert.Equal(t, relation.ID, deletedBefore.ID)
+	assert.Equal(t, "asset-001", deletedBefore.SourceAssetID)
 }
 
 // TestHandleRelationCreate_InvalidRelationType tests invalid relation type


### PR DESCRIPTION
## Summary
- Adds metadata change event subjects for assets and relations.
- Publishes best-effort created/updated/deleted events after successful metadata mutations.
- Emits auto-registration events from the data path while preserving configurable JetStream subjects and dead-letter behavior.
- Documents event schema and adapter reconciliation guidance.

## Validation
- go test ./...
- go test ./... -race -coverprofile=coverage.out

Closes #67
