### PR TITLE
feat: add asset registration modes (#82)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Metadata change events for asset and relation create/update/delete notifications
 - Go SDK for adapter development at `adapters/go/sdk` with feature parity to the Python SDK
 - Modbus TCP reference adapter examples for Python (`adapters/python/examples/modbus_tcp`) and Go (`adapters/go/sdk/examples/modbus_tcp_sensor`) with YAML-driven register mapping, configurable word order, and integration tests against in-process Modbus TCP servers
+- Configurable asset registration mode for choosing automatic metadata creation or manual asset governance
 
 ### Changed
 

--- a/cmd/core/main.go
+++ b/cmd/core/main.go
@@ -133,13 +133,12 @@ func main() {
 
 	// 6. Create handlers and subscribe
 	eventPublisher := core.NewEventPublisher(nc)
-	dataHandler := core.NewDataHandlerWithSubjects(
-		js,
-		store,
-		cfg.JetStream.ValidatedSubject,
-		cfg.JetStream.DeadLetterSubject,
-		eventPublisher,
-	)
+	dataHandler := core.NewDataHandlerWithConfig(js, store, core.DataHandlerOptions{
+		ValidatedSubject:  cfg.JetStream.ValidatedSubject,
+		DeadLetterSubject: cfg.JetStream.DeadLetterSubject,
+		Events:            eventPublisher,
+		RegistrationMode:  cfg.AssetRegistration.Mode,
+	})
 	metaHandler := core.NewMetaHandler(store, loader, eventPublisher)
 
 	_, err = nc.Subscribe("platform.data.asset", dataHandler.HandleAssetData)

--- a/deploy/configs/core/config.dev.yaml
+++ b/deploy/configs/core/config.dev.yaml
@@ -16,6 +16,11 @@ templates:
   dir: ./templates
   auto_reload: true
 
+asset_registration:
+  # auto creates Asset records for unknown asset_id values.
+  # manual keeps validated data flowing without creating Asset records.
+  mode: auto
+
 jetstream:
   validated_subject: platform.data.validated
   dead_letter_subject: platform.data.deadletter

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -123,6 +123,20 @@ Incoming JSON from adapters:
 
 EDG Core stores asset metadata in SQLite and exposes it through NATS metadata subjects.
 
+### Asset Registration Modes
+
+EDG Core controls unknown asset handling with `asset_registration.mode`.
+
+| Mode | Behavior |
+| --- | --- |
+| `auto` | Default. Unknown `asset_id` values from data messages create Asset records with `source: "auto"` and publish an asset-created metadata event. |
+| `manual` | Unknown `asset_id` values continue through the validated data subject, but EDG Core does not create Asset records or publish asset-created metadata events. |
+
+```yaml
+asset_registration:
+  mode: auto
+```
+
 Asset records include:
 - `id`: stable asset identifier
 - `name`: unique display name

--- a/internal/core/config.go
+++ b/internal/core/config.go
@@ -14,13 +14,19 @@ const (
 	DefaultDeadLetterSubject    = "platform.data.deadletter"
 )
 
+const (
+	RegistrationModeAuto   = "auto"
+	RegistrationModeManual = "manual"
+)
+
 // CoreConfig contains runtime settings for the embedded core process.
 type CoreConfig struct {
-	NATS      NATSConfig      `yaml:"nats"`
-	Storage   StorageConfig   `yaml:"storage"`
-	Templates TemplateConfig  `yaml:"templates"`
-	Logging   LoggingConfig   `yaml:"logging"`
-	JetStream JetStreamConfig `yaml:"jetstream"`
+	NATS              NATSConfig              `yaml:"nats"`
+	Storage           StorageConfig           `yaml:"storage"`
+	Templates         TemplateConfig          `yaml:"templates"`
+	Logging           LoggingConfig           `yaml:"logging"`
+	JetStream         JetStreamConfig         `yaml:"jetstream"`
+	AssetRegistration AssetRegistrationConfig `yaml:"asset_registration"`
 }
 
 type NATSConfig struct {
@@ -51,6 +57,10 @@ type JetStreamConfig struct {
 	Stream            JetStreamStreamConfig `yaml:"stream"`
 	ValidatedSubject  string                `yaml:"validated_subject"`
 	DeadLetterSubject string                `yaml:"dead_letter_subject"`
+}
+
+type AssetRegistrationConfig struct {
+	Mode string `yaml:"mode"`
 }
 
 type JetStreamStreamConfig struct {
@@ -101,6 +111,9 @@ func DefaultCoreConfig() CoreConfig {
 				Discard:   "old",
 			},
 		},
+		AssetRegistration: AssetRegistrationConfig{
+			Mode: RegistrationModeAuto,
+		},
 	}
 }
 
@@ -118,6 +131,9 @@ func LoadCoreConfig(path string) (CoreConfig, error) {
 		return cfg, fmt.Errorf("failed to parse core config: %w", err)
 	}
 	cfg.applyDefaults()
+	if err := cfg.validate(); err != nil {
+		return cfg, err
+	}
 	return cfg, nil
 }
 
@@ -151,7 +167,19 @@ func (c *CoreConfig) applyDefaults() {
 	if c.JetStream.DeadLetterSubject == "" {
 		c.JetStream.DeadLetterSubject = defaults.JetStream.DeadLetterSubject
 	}
+	if c.AssetRegistration.Mode == "" {
+		c.AssetRegistration.Mode = defaults.AssetRegistration.Mode
+	}
 	c.JetStream.Stream.applyDefaults(defaults.JetStream.Stream)
+}
+
+func (c CoreConfig) validate() error {
+	switch c.AssetRegistration.Mode {
+	case RegistrationModeAuto, RegistrationModeManual:
+		return nil
+	default:
+		return fmt.Errorf("invalid asset_registration.mode: %q (allowed: auto, manual)", c.AssetRegistration.Mode)
+	}
 }
 
 func (c *JetStreamStreamConfig) applyDefaults(defaults JetStreamStreamConfig) {

--- a/internal/core/config_test.go
+++ b/internal/core/config_test.go
@@ -26,6 +26,12 @@ func TestDefaultCoreConfig_JetStreamPolicy(t *testing.T) {
 	assert.True(t, cfg.Storage.AutoMigrate)
 }
 
+func TestDefaultCoreConfig_AssetRegistrationMode(t *testing.T) {
+	cfg := DefaultCoreConfig()
+
+	assert.Equal(t, RegistrationModeAuto, cfg.AssetRegistration.Mode)
+}
+
 func TestLoadCoreConfig_JetStreamPolicyFromYAML(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "config.yaml")
 	err := os.WriteFile(path, []byte(`
@@ -76,6 +82,34 @@ jetstream:
 	assert.Equal(t, nats.MemoryStorage, streamConfig.Storage)
 	assert.Equal(t, nats.DiscardNew, streamConfig.Discard)
 	assert.Equal(t, nats.LimitsPolicy, streamConfig.Retention)
+}
+
+func TestLoadCoreConfig_AssetRegistrationModeFromYAML(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	err := os.WriteFile(path, []byte(`
+asset_registration:
+  mode: manual
+`), 0644)
+	require.NoError(t, err)
+
+	cfg, err := LoadCoreConfig(path)
+	require.NoError(t, err)
+
+	assert.Equal(t, RegistrationModeManual, cfg.AssetRegistration.Mode)
+}
+
+func TestLoadCoreConfig_RejectsInvalidAssetRegistrationMode(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	err := os.WriteFile(path, []byte(`
+asset_registration:
+  mode: disabled
+`), 0644)
+	require.NoError(t, err)
+
+	_, err = LoadCoreConfig(path)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `invalid asset_registration.mode: "disabled"`)
 }
 
 func TestJetStreamStreamConfig_NATSConfigRejectsInvalidPolicies(t *testing.T) {

--- a/internal/core/handler.go
+++ b/internal/core/handler.go
@@ -18,6 +18,7 @@ type DataHandler struct {
 	js                nats.JetStreamContext // for publishing to JetStream
 	validatedSubject  string
 	deadLetterSubject string
+	registrationMode  string
 	events            *EventPublisher // for metadata change notifications
 }
 
@@ -26,6 +27,13 @@ var (
 	jetStreamDeadLetters     = expvar.NewInt("edg_core_jetstream_dead_letters")
 	jetStreamDeadLetterFails = expvar.NewInt("edg_core_jetstream_dead_letter_failures")
 )
+
+type DataHandlerOptions struct {
+	ValidatedSubject  string
+	DeadLetterSubject string
+	Events            *EventPublisher
+	RegistrationMode  string
+}
 
 // DeadLetterMessage records a failed core-to-JetStream publish attempt.
 type DeadLetterMessage struct {
@@ -41,25 +49,46 @@ func NewDataHandler(js nats.JetStreamContext, store *Store, events ...*EventPubl
 	if len(events) > 0 {
 		publisher = events[0]
 	}
+	return NewDataHandlerWithConfig(js, store, DataHandlerOptions{
+		Events: publisher,
+	})
+}
+
+func NewDataHandlerWithConfig(js nats.JetStreamContext, store *Store, opts DataHandlerOptions) *DataHandler {
+	validatedSubject := opts.ValidatedSubject
+	if validatedSubject == "" {
+		validatedSubject = DefaultValidatedDataSubject
+	}
+	deadLetterSubject := opts.DeadLetterSubject
+	if deadLetterSubject == "" {
+		deadLetterSubject = DefaultDeadLetterSubject
+	}
+	registrationMode := opts.RegistrationMode
+	if registrationMode == "" {
+		registrationMode = RegistrationModeAuto
+	}
+
 	return &DataHandler{
 		data:              make([]AssetData, 0),
 		store:             store,
 		js:                js,
-		validatedSubject:  DefaultValidatedDataSubject,
-		deadLetterSubject: DefaultDeadLetterSubject,
-		events:            publisher,
+		validatedSubject:  validatedSubject,
+		deadLetterSubject: deadLetterSubject,
+		registrationMode:  registrationMode,
+		events:            opts.Events,
 	}
 }
 
 func NewDataHandlerWithSubjects(js nats.JetStreamContext, store *Store, validatedSubject, deadLetterSubject string, events ...*EventPublisher) *DataHandler {
-	handler := NewDataHandler(js, store, events...)
-	if validatedSubject != "" {
-		handler.validatedSubject = validatedSubject
+	var publisher *EventPublisher
+	if len(events) > 0 {
+		publisher = events[0]
 	}
-	if deadLetterSubject != "" {
-		handler.deadLetterSubject = deadLetterSubject
-	}
-	return handler
+	return NewDataHandlerWithConfig(js, store, DataHandlerOptions{
+		ValidatedSubject:  validatedSubject,
+		DeadLetterSubject: deadLetterSubject,
+		Events:            publisher,
+	})
 }
 
 // HandleAssetData processes incoming NATS messages
@@ -70,25 +99,30 @@ func (h *DataHandler) HandleAssetData(msg *nats.Msg) {
 		return
 	}
 
-	// Auto-register asset if not exists
+	// Register metadata for unknown assets only when automatic registration is enabled.
 	if h.store != nil {
 		if exists, _ := h.store.AssetExists(data.AssetID); !exists {
-			now := time.Now()
-			asset := &Asset{
-				ID:        data.AssetID,
-				Name:      data.AssetID,
-				Source:    SourceAuto,
-				CreatedAt: now,
-				UpdatedAt: now,
-			}
-			if err := h.store.CreateAsset(asset); err == nil {
-				h.events.PublishAssetChanged(MetaChangeEvent{
-					EventType: EventCreated,
-					EntityID:  asset.ID,
+			switch h.registrationMode {
+			case RegistrationModeAuto:
+				now := time.Now()
+				asset := &Asset{
+					ID:        data.AssetID,
+					Name:      data.AssetID,
 					Source:    SourceAuto,
-					After:     asset,
-				})
-				log.Printf("[Core] Auto-registered asset: %s", data.AssetID)
+					CreatedAt: now,
+					UpdatedAt: now,
+				}
+				if err := h.store.CreateAsset(asset); err == nil {
+					h.events.PublishAssetChanged(MetaChangeEvent{
+						EventType: EventCreated,
+						EntityID:  asset.ID,
+						Source:    SourceAuto,
+						After:     asset,
+					})
+					log.Printf("[Core] Auto-registered asset: %s", data.AssetID)
+				}
+			case RegistrationModeManual:
+				log.Printf("[Core] unregistered asset (manual mode): %s", data.AssetID)
 			}
 		}
 	}

--- a/internal/core/handler_jetstream_test.go
+++ b/internal/core/handler_jetstream_test.go
@@ -150,6 +150,62 @@ func TestHandleAssetData_WithJetStreamAndStore(t *testing.T) {
 	assert.Equal(t, 1, handler.GetDataCount())
 }
 
+func TestHandleAssetData_ManualModePublishesValidatedData(t *testing.T) {
+	_, nc, js := startTestNATSServer(t, true)
+
+	_, err := js.AddStream(&nats.StreamConfig{
+		Name:     "MANUAL_MODE_STREAM",
+		Subjects: []string{"platform.data.>"},
+		Storage:  nats.MemoryStorage,
+	})
+	require.NoError(t, err)
+
+	store, err := NewStore(":memory:")
+	require.NoError(t, err)
+	defer store.Close()
+
+	handler := NewDataHandlerWithConfig(js, store, DataHandlerOptions{
+		RegistrationMode: RegistrationModeManual,
+	})
+
+	tempValue := 25.5
+	data := &AssetData{
+		AssetID:   "manual-jetstream-sensor",
+		Timestamp: 1234567890,
+		Values: []TagValue{
+			{Name: "temperature", Number: &tempValue, Unit: "celsius"},
+		},
+	}
+
+	jsonData, err := json.Marshal(data)
+	require.NoError(t, err)
+
+	received := make(chan *nats.Msg, 1)
+	sub, err := nc.Subscribe("platform.data.validated", func(msg *nats.Msg) {
+		received <- msg
+	})
+	require.NoError(t, err)
+	defer sub.Unsubscribe()
+	require.NoError(t, nc.Flush())
+
+	handler.HandleAssetData(&nats.Msg{
+		Subject: "platform.data.asset",
+		Data:    jsonData,
+	})
+
+	select {
+	case receivedMsg := <-received:
+		assert.Equal(t, jsonData, receivedMsg.Data)
+	case <-time.After(2 * time.Second):
+		t.Fatal("Timeout waiting for published message")
+	}
+
+	asset, err := store.GetAsset("manual-jetstream-sensor")
+	require.NoError(t, err)
+	assert.Nil(t, asset)
+	assert.Equal(t, 1, handler.GetDataCount())
+}
+
 // TestJetStreamPublish_MessagePersistence tests message persistence in JetStream
 func TestJetStreamPublish_MessagePersistence(t *testing.T) {
 	_, _, js := startTestNATSServer(t, true)

--- a/internal/core/handler_test.go
+++ b/internal/core/handler_test.go
@@ -94,6 +94,38 @@ func TestHandleAssetData_AutoRegister(t *testing.T) {
 	assert.False(t, asset.UpdatedAt.IsZero())
 }
 
+func TestHandleAssetData_ManualMode_DoesNotRegister(t *testing.T) {
+	store, err := NewStore(":memory:")
+	require.NoError(t, err)
+	defer store.Close()
+
+	handler := NewDataHandlerWithConfig(nil, store, DataHandlerOptions{
+		RegistrationMode: RegistrationModeManual,
+	})
+
+	tempValue := 25.5
+	data := &AssetData{
+		AssetID:   "manual-sensor",
+		Timestamp: 1234567890,
+		Values: []TagValue{
+			{Name: "temperature", Number: &tempValue},
+		},
+	}
+
+	jsonData, err := json.Marshal(data)
+	require.NoError(t, err)
+
+	handler.HandleAssetData(&nats.Msg{
+		Subject: "platform.data.raw",
+		Data:    jsonData,
+	})
+
+	asset, err := store.GetAsset("manual-sensor")
+	require.NoError(t, err)
+	assert.Nil(t, asset)
+	assert.Equal(t, 1, handler.GetDataCount())
+}
+
 func TestNewDataHandlerWithSubjects(t *testing.T) {
 	handler := NewDataHandlerWithSubjects(nil, nil, "custom.validated", "custom.deadletter")
 
@@ -104,6 +136,27 @@ func TestNewDataHandlerWithSubjects(t *testing.T) {
 	defaults := NewDataHandlerWithSubjects(nil, nil, "", "")
 	assert.Equal(t, DefaultValidatedDataSubject, defaults.validatedSubject)
 	assert.Equal(t, DefaultDeadLetterSubject, defaults.deadLetterSubject)
+}
+
+func TestNewDataHandlerWithConfig(t *testing.T) {
+	publisher := NewEventPublisher(nil)
+	handler := NewDataHandlerWithConfig(nil, nil, DataHandlerOptions{
+		ValidatedSubject:  "custom.validated",
+		DeadLetterSubject: "custom.deadletter",
+		Events:            publisher,
+		RegistrationMode:  RegistrationModeManual,
+	})
+
+	require.NotNil(t, handler)
+	assert.Equal(t, "custom.validated", handler.validatedSubject)
+	assert.Equal(t, "custom.deadletter", handler.deadLetterSubject)
+	assert.Equal(t, RegistrationModeManual, handler.registrationMode)
+	assert.Same(t, publisher, handler.events)
+
+	defaults := NewDataHandlerWithConfig(nil, nil, DataHandlerOptions{})
+	assert.Equal(t, DefaultValidatedDataSubject, defaults.validatedSubject)
+	assert.Equal(t, DefaultDeadLetterSubject, defaults.deadLetterSubject)
+	assert.Equal(t, RegistrationModeAuto, defaults.registrationMode)
 }
 
 func TestNewDataHandlerWithSubjectsAndEvents(t *testing.T) {
@@ -158,6 +211,37 @@ func TestHandleAssetData_AutoRegisterPublishesChangedEvent(t *testing.T) {
 	assert.Equal(t, SourceAuto, after.Source)
 }
 
+func TestHandleAssetData_ManualMode_NoChangeEvent(t *testing.T) {
+	_, nc, _ := startTestNATSServer(t, false)
+
+	store, err := NewStore(":memory:")
+	require.NoError(t, err)
+	defer store.Close()
+
+	assetEvents := subscribeMetaEvents(t, nc, SubjectAssetChanged)
+	handler := NewDataHandlerWithConfig(nil, store, DataHandlerOptions{
+		Events:           NewEventPublisher(nc),
+		RegistrationMode: RegistrationModeManual,
+	})
+
+	tempValue := 25.5
+	data := &AssetData{
+		AssetID: "manual-event-sensor",
+		Values: []TagValue{
+			{Name: "temperature", Number: &tempValue},
+		},
+	}
+	jsonData, err := json.Marshal(data)
+	require.NoError(t, err)
+
+	handler.HandleAssetData(&nats.Msg{Data: jsonData})
+
+	requireNoMetaEvent(t, assetEvents)
+	asset, err := store.GetAsset("manual-event-sensor")
+	require.NoError(t, err)
+	assert.Nil(t, asset)
+}
+
 // TestHandleAssetData_ExistingAssetDoesNotPublishChangedEvent tests existing asset ingestion.
 func TestHandleAssetData_ExistingAssetDoesNotPublishChangedEvent(t *testing.T) {
 	_, nc, _ := startTestNATSServer(t, false)
@@ -188,6 +272,44 @@ func TestHandleAssetData_ExistingAssetDoesNotPublishChangedEvent(t *testing.T) {
 
 	handler.HandleAssetData(&nats.Msg{Data: jsonData})
 	requireNoMetaEvent(t, assetEvents)
+}
+
+func TestHandleAssetData_ManualMode_ExistingAssetUnaffected(t *testing.T) {
+	store, err := NewStore(":memory:")
+	require.NoError(t, err)
+	defer store.Close()
+
+	createdAt := time.Now().Add(-time.Hour)
+	require.NoError(t, store.CreateAsset(&Asset{
+		ID:        "existing-manual-sensor",
+		Name:      "Existing Manual Sensor",
+		Source:    SourceManual,
+		CreatedAt: createdAt,
+		UpdatedAt: createdAt,
+	}))
+
+	handler := NewDataHandlerWithConfig(nil, store, DataHandlerOptions{
+		RegistrationMode: RegistrationModeManual,
+	})
+
+	tempValue := 25.5
+	data := &AssetData{
+		AssetID: "existing-manual-sensor",
+		Values: []TagValue{
+			{Name: "temperature", Number: &tempValue},
+		},
+	}
+	jsonData, err := json.Marshal(data)
+	require.NoError(t, err)
+
+	handler.HandleAssetData(&nats.Msg{Data: jsonData})
+
+	asset, err := store.GetAsset("existing-manual-sensor")
+	require.NoError(t, err)
+	require.NotNil(t, asset)
+	assert.Equal(t, "Existing Manual Sensor", asset.Name)
+	assert.Equal(t, SourceManual, asset.Source)
+	assert.Equal(t, 1, handler.GetDataCount())
 }
 
 // TestGetDataCount tests thread-safe data count


### PR DESCRIPTION
## Summary

- Add `asset_registration.mode` with `auto` as the backward-compatible default and `manual` for metadata-governed deployments.
- Add `DataHandlerOptions` and wire core startup to pass asset registration mode from config.
- Keep validated data publishing intact in manual mode while suppressing automatic Asset creation and asset-created metadata events.
- Document the setting and expose it in the development config.

## Validation

- `go test ./internal/core/... -v`
- `go test ./...`
- `go build ./...`