### PR TITLE
feat: add alarm impact analysis (#85)

### DIFF
--- a/cmd/core/main.go
+++ b/cmd/core/main.go
@@ -149,6 +149,10 @@ func main() {
 		Enricher:          enricher,
 	})
 	metaHandler := core.NewMetaHandler(store, loader, eventPublisher)
+	alarmHandler := core.NewAlarmHandler(store, eventPublisher, core.AlarmHandlerOptions{
+		Window:            time.Duration(cfg.Alarm.WindowSeconds) * time.Second,
+		MaxTraversalDepth: cfg.Alarm.MaxTraversalDepth,
+	})
 
 	_, err = nc.Subscribe("platform.data.asset", dataHandler.HandleAssetData)
 	if err != nil {
@@ -157,6 +161,9 @@ func main() {
 
 	if err := metaHandler.RegisterHandlers(nc); err != nil {
 		log.Fatalf("Failed to register meta handlers: %v", err)
+	}
+	if err := alarmHandler.RegisterHandlers(nc); err != nil {
+		log.Fatalf("Failed to register alarm handlers: %v", err)
 	}
 
 	log.Println("[Core] Subscribed to: platform.data.asset")

--- a/deploy/configs/core/config.dev.yaml
+++ b/deploy/configs/core/config.dev.yaml
@@ -21,6 +21,10 @@ asset_registration:
   # manual keeps validated data flowing without creating Asset records.
   mode: auto
 
+alarm:
+  window_seconds: 5
+  max_traversal_depth: 10
+
 jetstream:
   validated_subject: platform.data.validated
   dead_letter_subject: platform.data.deadletter

--- a/deploy/configs/core/config.prod.yaml
+++ b/deploy/configs/core/config.prod.yaml
@@ -16,6 +16,10 @@ templates:
   dir: /etc/edg/templates
   auto_reload: false
 
+alarm:
+  window_seconds: 5
+  max_traversal_depth: 10
+
 jetstream:
   validated_subject: platform.data.validated
   dead_letter_subject: platform.data.deadletter

--- a/deploy/configs/core/config.staging.yaml
+++ b/deploy/configs/core/config.staging.yaml
@@ -16,6 +16,10 @@ templates:
   dir: /etc/edg/templates
   auto_reload: true
 
+alarm:
+  window_seconds: 5
+  max_traversal_depth: 10
+
 jetstream:
   validated_subject: platform.data.validated
   dead_letter_subject: platform.data.deadletter

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -237,6 +237,40 @@ If `relation_types` is omitted for tree traversal, core uses `partOf` and
 `locatedIn`. If `relation_type` is omitted for `connected`, core returns all
 one-hop relation types.
 
+## Alarm Impact Analysis
+
+Adapters and internal components can raise alarms by publishing JSON to
+`platform.alarm.raised`:
+
+```json
+{
+  "id": "alarm-001",
+  "asset_id": "pump-A",
+  "severity": "critical",
+  "code": "pump.offline",
+  "message": "Pump A offline"
+}
+```
+
+Core validates that the asset exists, computes downstream impact with the asset
+relation graph, and immediately publishes `platform.alarm.impact.computed`.
+Downstream impact uses `partOf` and `locatedIn`; one-hop `connectedTo` assets are
+included separately in `connected_asset_ids`.
+
+Short alarm floods are grouped in memory. When the grouping window closes, core
+publishes `platform.alarm.grouped` with the nearest common ancestor, alarm IDs,
+asset IDs, and highest severity in the group.
+
+```yaml
+alarm:
+  window_seconds: 5
+  max_traversal_depth: 10
+```
+
+The in-memory window is intentionally short-lived. If the core process restarts,
+pending groups that have not yet been emitted are lost; durable alarm history is
+outside this PoC scope.
+
 ## Monitoring
 
 - **NATS Monitor**: http://localhost:8222

--- a/internal/core/alarm.go
+++ b/internal/core/alarm.go
@@ -1,0 +1,83 @@
+package core
+
+import "time"
+
+// Severity describes alarm urgency. Higher severities dominate grouped alarms.
+type Severity string
+
+const (
+	SeverityInfo     Severity = "info"
+	SeverityWarning  Severity = "warning"
+	SeverityCritical Severity = "critical"
+)
+
+// Alarm is published to SubjectAlarmRaised by adapters or core internals.
+type Alarm struct {
+	ID        string            `json:"id"`
+	AssetID   string            `json:"asset_id"`
+	Severity  Severity          `json:"severity"`
+	Code      string            `json:"code,omitempty"`
+	Message   string            `json:"message,omitempty"`
+	Source    string            `json:"source,omitempty"`
+	Timestamp time.Time         `json:"timestamp"`
+	Metadata  map[string]string `json:"metadata,omitempty"`
+}
+
+// AlarmImpact is published immediately after an alarm is accepted.
+type AlarmImpact struct {
+	Alarm             Alarm        `json:"alarm"`
+	AffectedAssets    []*AssetNode `json:"affected_assets,omitempty"`
+	AffectedAssetIDs  []string     `json:"affected_asset_ids,omitempty"`
+	ConnectedAssets   []*AssetNode `json:"connected_assets,omitempty"`
+	ConnectedAssetIDs []string     `json:"connected_asset_ids,omitempty"`
+	ComputedAt        time.Time    `json:"computed_at"`
+	MaxDepth          int          `json:"max_depth"`
+}
+
+// AlarmGroup is published when the flooding suppression window closes.
+type AlarmGroup struct {
+	ID                string    `json:"id"`
+	GroupAssetID      string    `json:"group_asset_id"`
+	GroupAssetName    string    `json:"group_asset_name,omitempty"`
+	GroupTemplateName string    `json:"group_template_name,omitempty"`
+	Severity          Severity  `json:"severity"`
+	AlarmCount        int       `json:"alarm_count"`
+	AlarmIDs          []string  `json:"alarm_ids"`
+	AssetIDs          []string  `json:"asset_ids"`
+	Alarms            []Alarm   `json:"alarms"`
+	WindowStartedAt   time.Time `json:"window_started_at"`
+	WindowEndedAt     time.Time `json:"window_ended_at"`
+	CreatedAt         time.Time `json:"created_at"`
+}
+
+func (s Severity) IsValid() bool {
+	switch s {
+	case SeverityInfo, SeverityWarning, SeverityCritical:
+		return true
+	default:
+		return false
+	}
+}
+
+func (s Severity) rank() int {
+	switch s {
+	case SeverityCritical:
+		return 3
+	case SeverityWarning:
+		return 2
+	case SeverityInfo:
+		return 1
+	default:
+		return 0
+	}
+}
+
+func maxAlarmSeverity(alarms []Alarm) Severity {
+	max := SeverityInfo
+	for _, alarm := range alarms {
+		if alarm.Severity.rank() > max.rank() {
+			max = alarm.Severity
+		}
+	}
+	return max
+}

--- a/internal/core/alarm_aggregator.go
+++ b/internal/core/alarm_aggregator.go
@@ -1,0 +1,250 @@
+package core
+
+import (
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+const DefaultAlarmWindow = 5 * time.Second
+
+type AlarmGroupPublisher interface {
+	PublishAlarmGrouped(group AlarmGroup)
+}
+
+type AlarmAggregatorOptions struct {
+	Window        time.Duration
+	RelationTypes []RelationType
+	MaxDepth      int
+}
+
+type AlarmAggregator struct {
+	store         *Store
+	publisher     AlarmGroupPublisher
+	window        time.Duration
+	relationTypes []RelationType
+	maxDepth      int
+
+	mu     sync.Mutex
+	groups map[string]*pendingAlarmGroup
+}
+
+type pendingAlarmGroup struct {
+	key             string
+	groupAsset      *AssetNode
+	alarms          []Alarm
+	assetIDs        []string
+	assetIDSet      map[string]bool
+	windowStartedAt time.Time
+	timer           *time.Timer
+}
+
+func NewAlarmAggregator(store *Store, publisher AlarmGroupPublisher, opts AlarmAggregatorOptions) *AlarmAggregator {
+	window := opts.Window
+	if window <= 0 {
+		window = DefaultAlarmWindow
+	}
+	relationTypes := opts.RelationTypes
+	if len(relationTypes) == 0 {
+		relationTypes = DefaultHierarchicalRelationTypes()
+	}
+	maxDepth := opts.MaxDepth
+	if maxDepth <= 0 {
+		maxDepth = DefaultTraversalMaxDepth
+	}
+
+	return &AlarmAggregator{
+		store:         store,
+		publisher:     publisher,
+		window:        window,
+		relationTypes: append([]RelationType(nil), relationTypes...),
+		maxDepth:      maxDepth,
+		groups:        make(map[string]*pendingAlarmGroup),
+	}
+}
+
+func (a *AlarmAggregator) Add(alarm Alarm) error {
+	if a == nil {
+		return nil
+	}
+	alarm = normalizeAlarm(alarm)
+
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	group, lca, err := a.findGroupForAssetLocked(alarm.AssetID)
+	if err != nil {
+		return err
+	}
+	if group == nil {
+		group = a.newPendingGroupLocked(alarm)
+		return nil
+	}
+
+	oldKey := group.key
+	group.alarms = append(group.alarms, alarm)
+	if !group.assetIDSet[alarm.AssetID] {
+		group.assetIDSet[alarm.AssetID] = true
+		group.assetIDs = append(group.assetIDs, alarm.AssetID)
+	}
+	if lca != nil {
+		group.groupAsset = lca
+		group.key = lca.ID
+	}
+
+	if oldKey != group.key {
+		delete(a.groups, oldKey)
+		if existing := a.groups[group.key]; existing != nil && existing != group {
+			a.mergeGroupsLocked(existing, group)
+			group = existing
+		}
+		a.groups[group.key] = group
+	}
+	return nil
+}
+
+func (a *AlarmAggregator) newPendingGroupLocked(alarm Alarm) *pendingAlarmGroup {
+	now := time.Now().UTC()
+	groupAsset := a.assetNodeFor(alarm.AssetID)
+	group := &pendingAlarmGroup{
+		key:             groupAsset.ID,
+		groupAsset:      groupAsset,
+		alarms:          []Alarm{alarm},
+		assetIDs:        []string{alarm.AssetID},
+		assetIDSet:      map[string]bool{alarm.AssetID: true},
+		windowStartedAt: now,
+	}
+	group.timer = time.AfterFunc(a.window, func() {
+		a.flush(group)
+	})
+	a.groups[group.key] = group
+	return group
+}
+
+func (a *AlarmAggregator) findGroupForAssetLocked(assetID string) (*pendingAlarmGroup, *AssetNode, error) {
+	if a.store == nil {
+		return nil, nil, nil
+	}
+
+	var selected *pendingAlarmGroup
+	var selectedLCA *AssetNode
+	for _, group := range a.groups {
+		candidates := append([]string{}, group.assetIDs...)
+		candidates = append(candidates, assetID)
+		lca, err := a.store.FindLowestCommonAncestor(candidates, a.relationTypes, a.maxDepth)
+		if err != nil {
+			return nil, nil, err
+		}
+		if lca == nil {
+			continue
+		}
+		if selectedLCA == nil || lca.Depth < selectedLCA.Depth || (lca.Depth == selectedLCA.Depth && lca.ID < selectedLCA.ID) {
+			selected = group
+			selectedLCA = lca
+		}
+	}
+	return selected, selectedLCA, nil
+}
+
+func (a *AlarmAggregator) mergeGroupsLocked(dst, src *pendingAlarmGroup) {
+	if src.timer != nil {
+		src.timer.Stop()
+	}
+	dst.alarms = append(dst.alarms, src.alarms...)
+	for _, assetID := range src.assetIDs {
+		if dst.assetIDSet[assetID] {
+			continue
+		}
+		dst.assetIDSet[assetID] = true
+		dst.assetIDs = append(dst.assetIDs, assetID)
+	}
+}
+
+func (a *AlarmAggregator) flush(group *pendingAlarmGroup) {
+	a.mu.Lock()
+	if current := a.groups[group.key]; current != group {
+		a.mu.Unlock()
+		return
+	}
+	delete(a.groups, group.key)
+	alarmGroup := group.toAlarmGroup(time.Now().UTC())
+	a.mu.Unlock()
+
+	if a.publisher != nil {
+		a.publisher.PublishAlarmGrouped(alarmGroup)
+	}
+}
+
+func (g *pendingAlarmGroup) toAlarmGroup(now time.Time) AlarmGroup {
+	alarmIDs := make([]string, 0, len(g.alarms))
+	alarms := make([]Alarm, len(g.alarms))
+	copy(alarms, g.alarms)
+	for _, alarm := range g.alarms {
+		alarmIDs = append(alarmIDs, alarm.ID)
+	}
+	assetIDs := append([]string(nil), g.assetIDs...)
+
+	group := AlarmGroup{
+		ID:              uuid.New().String(),
+		Severity:        maxAlarmSeverity(g.alarms),
+		AlarmCount:      len(g.alarms),
+		AlarmIDs:        alarmIDs,
+		AssetIDs:        assetIDs,
+		Alarms:          alarms,
+		WindowStartedAt: g.windowStartedAt,
+		WindowEndedAt:   now,
+		CreatedAt:       now,
+	}
+	if g.groupAsset != nil {
+		group.GroupAssetID = g.groupAsset.ID
+		group.GroupAssetName = g.groupAsset.Name
+		group.GroupTemplateName = g.groupAsset.TemplateName
+	}
+	return group
+}
+
+func (a *AlarmAggregator) assetNodeFor(assetID string) *AssetNode {
+	if a.store != nil {
+		asset, err := a.store.GetAsset(assetID)
+		if err == nil && asset != nil {
+			return &AssetNode{
+				ID:           asset.ID,
+				Name:         asset.Name,
+				TemplateName: asset.TemplateName,
+				Depth:        0,
+			}
+		}
+	}
+	return &AssetNode{ID: assetID, Name: assetID, Depth: 0}
+}
+
+func normalizeAlarm(alarm Alarm) Alarm {
+	if alarm.ID == "" {
+		alarm.ID = uuid.New().String()
+	}
+	if alarm.Timestamp.IsZero() {
+		alarm.Timestamp = time.Now().UTC()
+	}
+	if alarm.Severity == "" {
+		alarm.Severity = SeverityInfo
+	}
+	if alarm.Metadata == nil {
+		alarm.Metadata = map[string]string{}
+	}
+	return alarm
+}
+
+func validateAlarm(alarm Alarm) error {
+	if alarm.AssetID == "" {
+		return fmt.Errorf("asset_id is required")
+	}
+	if alarm.Severity == "" {
+		return nil
+	}
+	if !alarm.Severity.IsValid() {
+		return fmt.Errorf("invalid severity: %s", alarm.Severity)
+	}
+	return nil
+}

--- a/internal/core/alarm_aggregator_test.go
+++ b/internal/core/alarm_aggregator_test.go
@@ -1,0 +1,83 @@
+package core
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type recordingAlarmGroupPublisher struct {
+	mu     sync.Mutex
+	groups []AlarmGroup
+	ch     chan AlarmGroup
+}
+
+func newRecordingAlarmGroupPublisher() *recordingAlarmGroupPublisher {
+	return &recordingAlarmGroupPublisher{
+		ch: make(chan AlarmGroup, 8),
+	}
+}
+
+func (p *recordingAlarmGroupPublisher) PublishAlarmGrouped(group AlarmGroup) {
+	p.mu.Lock()
+	p.groups = append(p.groups, group)
+	p.mu.Unlock()
+	p.ch <- group
+}
+
+func (p *recordingAlarmGroupPublisher) waitGroup(t *testing.T) AlarmGroup {
+	t.Helper()
+
+	select {
+	case group := <-p.ch:
+		return group
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for alarm group")
+		return AlarmGroup{}
+	}
+}
+
+func TestAlarmAggregator_GroupsSiblingAlarmsByNearestCommonAncestor(t *testing.T) {
+	store := newAlarmTestStore(t)
+	publisher := newRecordingAlarmGroupPublisher()
+	aggregator := NewAlarmAggregator(store, publisher, AlarmAggregatorOptions{
+		Window:   20 * time.Millisecond,
+		MaxDepth: 10,
+	})
+
+	require.NoError(t, aggregator.Add(Alarm{ID: "alarm-1", AssetID: "sensor-001", Severity: SeverityCritical}))
+	require.NoError(t, aggregator.Add(Alarm{ID: "alarm-2", AssetID: "sensor-002", Severity: SeverityWarning}))
+
+	group := publisher.waitGroup(t)
+	assert.Equal(t, "pump-a", group.GroupAssetID)
+	assert.Equal(t, 2, group.AlarmCount)
+	assert.ElementsMatch(t, []string{"alarm-1", "alarm-2"}, group.AlarmIDs)
+	assert.ElementsMatch(t, []string{"sensor-001", "sensor-002"}, group.AssetIDs)
+	assert.Equal(t, SeverityCritical, group.Severity)
+	assert.False(t, group.WindowStartedAt.IsZero())
+	assert.False(t, group.WindowEndedAt.IsZero())
+}
+
+func TestAlarmAggregator_SeparatesAlarmsWithoutCommonAncestor(t *testing.T) {
+	store := newAlarmTestStore(t)
+	createTraversalAsset(t, store, "isolated-sensor", "Isolated Sensor", "sensor")
+	publisher := newRecordingAlarmGroupPublisher()
+	aggregator := NewAlarmAggregator(store, publisher, AlarmAggregatorOptions{
+		Window:   20 * time.Millisecond,
+		MaxDepth: 10,
+	})
+
+	require.NoError(t, aggregator.Add(Alarm{ID: "alarm-1", AssetID: "sensor-001", Severity: SeverityWarning}))
+	require.NoError(t, aggregator.Add(Alarm{ID: "alarm-2", AssetID: "isolated-sensor", Severity: SeverityInfo}))
+
+	first := publisher.waitGroup(t)
+	second := publisher.waitGroup(t)
+
+	groupIDs := []string{first.GroupAssetID, second.GroupAssetID}
+	assert.ElementsMatch(t, []string{"sensor-001", "isolated-sensor"}, groupIDs)
+	assert.Equal(t, 1, first.AlarmCount)
+	assert.Equal(t, 1, second.AlarmCount)
+}

--- a/internal/core/alarm_handler.go
+++ b/internal/core/alarm_handler.go
@@ -1,0 +1,138 @@
+package core
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/nats-io/nats.go"
+)
+
+type AlarmHandlerOptions struct {
+	Window            time.Duration
+	RelationTypes     []RelationType
+	MaxTraversalDepth int
+}
+
+type AlarmHandler struct {
+	store         *Store
+	publisher     *EventPublisher
+	aggregator    *AlarmAggregator
+	relationTypes []RelationType
+	maxDepth      int
+}
+
+func NewAlarmHandler(store *Store, publisher *EventPublisher, opts AlarmHandlerOptions) *AlarmHandler {
+	relationTypes := opts.RelationTypes
+	if len(relationTypes) == 0 {
+		relationTypes = DefaultHierarchicalRelationTypes()
+	}
+	maxDepth := opts.MaxTraversalDepth
+	if maxDepth <= 0 {
+		maxDepth = DefaultTraversalMaxDepth
+	}
+
+	aggregator := NewAlarmAggregator(store, publisher, AlarmAggregatorOptions{
+		Window:        opts.Window,
+		RelationTypes: relationTypes,
+		MaxDepth:      maxDepth,
+	})
+	return &AlarmHandler{
+		store:         store,
+		publisher:     publisher,
+		aggregator:    aggregator,
+		relationTypes: append([]RelationType(nil), relationTypes...),
+		maxDepth:      maxDepth,
+	}
+}
+
+func (h *AlarmHandler) RegisterHandlers(nc *nats.Conn) error {
+	if h == nil || nc == nil {
+		return nil
+	}
+	if _, err := nc.Subscribe(SubjectAlarmRaised, h.handleAlarmRaised); err != nil {
+		return err
+	}
+	log.Printf("[Alarm] Subscribed: %s", SubjectAlarmRaised)
+	return nil
+}
+
+func (h *AlarmHandler) handleAlarmRaised(msg *nats.Msg) {
+	var alarm Alarm
+	if err := json.Unmarshal(msg.Data, &alarm); err != nil {
+		log.Printf("[Alarm] Invalid alarm payload: %v", err)
+		return
+	}
+	if err := h.Process(alarm); err != nil {
+		log.Printf("[Alarm] Failed to process alarm: %v", err)
+	}
+}
+
+func (h *AlarmHandler) Process(alarm Alarm) error {
+	if h == nil {
+		return nil
+	}
+	alarm = normalizeAlarm(alarm)
+	if err := validateAlarm(alarm); err != nil {
+		return err
+	}
+
+	impact, err := h.ComputeImpact(alarm)
+	if err != nil {
+		return err
+	}
+	h.publisher.PublishAlarmImpactComputed(impact)
+
+	if h.aggregator != nil {
+		if err := h.aggregator.Add(alarm); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (h *AlarmHandler) ComputeImpact(alarm Alarm) (AlarmImpact, error) {
+	if h == nil || h.store == nil {
+		return AlarmImpact{}, fmt.Errorf("store is required")
+	}
+	asset, err := h.store.GetAsset(alarm.AssetID)
+	if err != nil {
+		return AlarmImpact{}, err
+	}
+	if asset == nil {
+		return AlarmImpact{}, fmt.Errorf("asset not found: %s", alarm.AssetID)
+	}
+
+	affected, err := h.store.GetDescendants(alarm.AssetID, h.relationTypes, h.maxDepth)
+	if err != nil {
+		return AlarmImpact{}, err
+	}
+	connected, err := h.store.GetConnected(alarm.AssetID, RelationConnectedTo)
+	if err != nil {
+		return AlarmImpact{}, err
+	}
+
+	return AlarmImpact{
+		Alarm:             alarm,
+		AffectedAssets:    affected,
+		AffectedAssetIDs:  assetNodeIDs(affected),
+		ConnectedAssets:   connected,
+		ConnectedAssetIDs: assetNodeIDs(connected),
+		ComputedAt:        time.Now().UTC(),
+		MaxDepth:          h.maxDepth,
+	}, nil
+}
+
+func assetNodeIDs(nodes []*AssetNode) []string {
+	ids := make([]string, 0, len(nodes))
+	seen := make(map[string]bool, len(nodes))
+	for _, node := range nodes {
+		if node == nil || seen[node.ID] {
+			continue
+		}
+		seen[node.ID] = true
+		ids = append(ids, node.ID)
+	}
+	return ids
+}

--- a/internal/core/alarm_handler_test.go
+++ b/internal/core/alarm_handler_test.go
@@ -1,0 +1,156 @@
+package core
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/nats-io/nats.go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStoreTraversal_FindLowestCommonAncestor(t *testing.T) {
+	store := newAlarmTestStore(t)
+
+	lca, err := store.FindLowestCommonAncestor(
+		[]string{"sensor-001", "sensor-002"},
+		[]RelationType{RelationPartOf},
+		10,
+	)
+
+	require.NoError(t, err)
+	require.NotNil(t, lca)
+	assert.Equal(t, "pump-a", lca.ID)
+	assert.Equal(t, 1, lca.Depth)
+}
+
+func TestStoreTraversal_FindLowestCommonAncestorReturnsNilForSeparateTrees(t *testing.T) {
+	store := newAlarmTestStore(t)
+	createTraversalAsset(t, store, "isolated-sensor", "Isolated Sensor", "sensor")
+
+	lca, err := store.FindLowestCommonAncestor(
+		[]string{"sensor-001", "isolated-sensor"},
+		[]RelationType{RelationPartOf},
+		10,
+	)
+
+	require.NoError(t, err)
+	assert.Nil(t, lca)
+}
+
+func TestAlarmHandler_PublishesImpactAndGroupedEvents(t *testing.T) {
+	_, nc, _ := startTestNATSServer(t, false)
+	store := newAlarmTestStore(t)
+
+	impactCh := subscribeAlarmImpact(t, nc)
+	groupCh := subscribeAlarmGroup(t, nc)
+
+	handler := NewAlarmHandler(store, NewEventPublisher(nc), AlarmHandlerOptions{
+		Window:            20 * time.Millisecond,
+		MaxTraversalDepth: 10,
+	})
+	require.NoError(t, handler.RegisterHandlers(nc))
+	require.NoError(t, nc.Flush())
+
+	alarm := Alarm{
+		ID:        "alarm-1",
+		AssetID:   "pump-a",
+		Severity:  SeverityCritical,
+		Code:      "pump.offline",
+		Message:   "Pump A offline",
+		Timestamp: time.Now().UTC(),
+	}
+	data, err := json.Marshal(alarm)
+	require.NoError(t, err)
+	require.NoError(t, nc.Publish(SubjectAlarmRaised, data))
+
+	impact := requireAlarmImpact(t, impactCh)
+	assert.Equal(t, "alarm-1", impact.Alarm.ID)
+	assert.Equal(t, "pump-a", impact.Alarm.AssetID)
+	assert.ElementsMatch(t, []string{"sensor-001", "sensor-002"}, impact.AffectedAssetIDs)
+
+	group := requireAlarmGroup(t, groupCh)
+	assert.Equal(t, "pump-a", group.GroupAssetID)
+	assert.Equal(t, 1, group.AlarmCount)
+	assert.Equal(t, []string{"alarm-1"}, group.AlarmIDs)
+}
+
+func TestAlarmHandler_RejectsMissingAsset(t *testing.T) {
+	store := newAlarmTestStore(t)
+	handler := NewAlarmHandler(store, nil, AlarmHandlerOptions{})
+
+	err := handler.Process(Alarm{ID: "alarm-missing", AssetID: "missing", Severity: SeverityWarning})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "asset not found")
+}
+
+func subscribeAlarmImpact(t *testing.T, nc *nats.Conn) chan AlarmImpact {
+	t.Helper()
+
+	ch := make(chan AlarmImpact, 4)
+	sub, err := nc.Subscribe(SubjectAlarmImpactComputed, func(msg *nats.Msg) {
+		var impact AlarmImpact
+		if err := json.Unmarshal(msg.Data, &impact); err == nil {
+			ch <- impact
+		}
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = sub.Unsubscribe()
+	})
+	require.NoError(t, nc.Flush())
+	return ch
+}
+
+func subscribeAlarmGroup(t *testing.T, nc *nats.Conn) chan AlarmGroup {
+	t.Helper()
+
+	ch := make(chan AlarmGroup, 4)
+	sub, err := nc.Subscribe(SubjectAlarmGrouped, func(msg *nats.Msg) {
+		var group AlarmGroup
+		if err := json.Unmarshal(msg.Data, &group); err == nil {
+			ch <- group
+		}
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = sub.Unsubscribe()
+	})
+	require.NoError(t, nc.Flush())
+	return ch
+}
+
+func requireAlarmImpact(t *testing.T, ch <-chan AlarmImpact) AlarmImpact {
+	t.Helper()
+
+	select {
+	case impact := <-ch:
+		return impact
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for alarm impact")
+		return AlarmImpact{}
+	}
+}
+
+func requireAlarmGroup(t *testing.T, ch <-chan AlarmGroup) AlarmGroup {
+	t.Helper()
+
+	select {
+	case group := <-ch:
+		return group
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for alarm group")
+		return AlarmGroup{}
+	}
+}
+
+func newAlarmTestStore(t *testing.T) *Store {
+	t.Helper()
+
+	store := newTraversalTestStore(t)
+	createTraversalAsset(t, store, "sensor-002", "Sensor 002", "sensor")
+	createTraversalRelation(t, store, "rel-sensor-002-pump", "sensor-002", "pump-a", RelationPartOf)
+	return store
+}

--- a/internal/core/config.go
+++ b/internal/core/config.go
@@ -27,6 +27,7 @@ type CoreConfig struct {
 	Logging           LoggingConfig           `yaml:"logging"`
 	JetStream         JetStreamConfig         `yaml:"jetstream"`
 	AssetRegistration AssetRegistrationConfig `yaml:"asset_registration"`
+	Alarm             AlarmConfig             `yaml:"alarm"`
 }
 
 type NATSConfig struct {
@@ -61,6 +62,11 @@ type JetStreamConfig struct {
 
 type AssetRegistrationConfig struct {
 	Mode string `yaml:"mode"`
+}
+
+type AlarmConfig struct {
+	WindowSeconds     int `yaml:"window_seconds"`
+	MaxTraversalDepth int `yaml:"max_traversal_depth"`
 }
 
 type JetStreamStreamConfig struct {
@@ -113,6 +119,10 @@ func DefaultCoreConfig() CoreConfig {
 		},
 		AssetRegistration: AssetRegistrationConfig{
 			Mode: RegistrationModeAuto,
+		},
+		Alarm: AlarmConfig{
+			WindowSeconds:     int(DefaultAlarmWindow / time.Second),
+			MaxTraversalDepth: DefaultTraversalMaxDepth,
 		},
 	}
 }
@@ -170,16 +180,28 @@ func (c *CoreConfig) applyDefaults() {
 	if c.AssetRegistration.Mode == "" {
 		c.AssetRegistration.Mode = defaults.AssetRegistration.Mode
 	}
+	if c.Alarm.WindowSeconds == 0 {
+		c.Alarm.WindowSeconds = defaults.Alarm.WindowSeconds
+	}
+	if c.Alarm.MaxTraversalDepth == 0 {
+		c.Alarm.MaxTraversalDepth = defaults.Alarm.MaxTraversalDepth
+	}
 	c.JetStream.Stream.applyDefaults(defaults.JetStream.Stream)
 }
 
 func (c CoreConfig) validate() error {
 	switch c.AssetRegistration.Mode {
 	case RegistrationModeAuto, RegistrationModeManual:
-		return nil
 	default:
 		return fmt.Errorf("invalid asset_registration.mode: %q (allowed: auto, manual)", c.AssetRegistration.Mode)
 	}
+	if c.Alarm.WindowSeconds <= 0 {
+		return fmt.Errorf("invalid alarm.window_seconds: %d (must be > 0)", c.Alarm.WindowSeconds)
+	}
+	if c.Alarm.MaxTraversalDepth <= 0 {
+		return fmt.Errorf("invalid alarm.max_traversal_depth: %d (must be > 0)", c.Alarm.MaxTraversalDepth)
+	}
+	return nil
 }
 
 func (c *JetStreamStreamConfig) applyDefaults(defaults JetStreamStreamConfig) {

--- a/internal/core/config_test.go
+++ b/internal/core/config_test.go
@@ -32,6 +32,13 @@ func TestDefaultCoreConfig_AssetRegistrationMode(t *testing.T) {
 	assert.Equal(t, RegistrationModeAuto, cfg.AssetRegistration.Mode)
 }
 
+func TestDefaultCoreConfig_Alarm(t *testing.T) {
+	cfg := DefaultCoreConfig()
+
+	assert.Equal(t, 5, cfg.Alarm.WindowSeconds)
+	assert.Equal(t, DefaultTraversalMaxDepth, cfg.Alarm.MaxTraversalDepth)
+}
+
 func TestLoadCoreConfig_JetStreamPolicyFromYAML(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "config.yaml")
 	err := os.WriteFile(path, []byte(`
@@ -98,6 +105,22 @@ asset_registration:
 	assert.Equal(t, RegistrationModeManual, cfg.AssetRegistration.Mode)
 }
 
+func TestLoadCoreConfig_AlarmFromYAML(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	err := os.WriteFile(path, []byte(`
+alarm:
+  window_seconds: 2
+  max_traversal_depth: 4
+`), 0644)
+	require.NoError(t, err)
+
+	cfg, err := LoadCoreConfig(path)
+	require.NoError(t, err)
+
+	assert.Equal(t, 2, cfg.Alarm.WindowSeconds)
+	assert.Equal(t, 4, cfg.Alarm.MaxTraversalDepth)
+}
+
 func TestLoadCoreConfig_RejectsInvalidAssetRegistrationMode(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "config.yaml")
 	err := os.WriteFile(path, []byte(`
@@ -110,6 +133,20 @@ asset_registration:
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), `invalid asset_registration.mode: "disabled"`)
+}
+
+func TestLoadCoreConfig_RejectsInvalidAlarmConfig(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	err := os.WriteFile(path, []byte(`
+alarm:
+  window_seconds: -1
+`), 0644)
+	require.NoError(t, err)
+
+	_, err = LoadCoreConfig(path)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid alarm.window_seconds")
 }
 
 func TestJetStreamStreamConfig_NATSConfigRejectsInvalidPolicies(t *testing.T) {

--- a/internal/core/events.go
+++ b/internal/core/events.go
@@ -17,6 +17,10 @@ const (
 	SubjectAssetSubtree     = "platform.meta.asset.subtree"
 	SubjectAssetConnected   = "platform.meta.asset.connected"
 
+	SubjectAlarmRaised         = "platform.alarm.raised"
+	SubjectAlarmImpactComputed = "platform.alarm.impact.computed"
+	SubjectAlarmGrouped        = "platform.alarm.grouped"
+
 	EventSchemaVersion = 1
 )
 
@@ -62,19 +66,31 @@ func (p *EventPublisher) PublishRelationChanged(ev MetaChangeEvent) {
 	p.publishMetaChange(SubjectRelationChanged, normalizeMetaChangeEvent(ev, EntityRelation))
 }
 
+func (p *EventPublisher) PublishAlarmImpactComputed(impact AlarmImpact) {
+	p.publishJSON(SubjectAlarmImpactComputed, impact)
+}
+
+func (p *EventPublisher) PublishAlarmGrouped(group AlarmGroup) {
+	p.publishJSON(SubjectAlarmGrouped, group)
+}
+
 func (p *EventPublisher) publishMetaChange(subject string, ev MetaChangeEvent) {
+	p.publishJSON(subject, ev)
+}
+
+func (p *EventPublisher) publishJSON(subject string, payload any) {
 	if p == nil || p.nc == nil {
 		return
 	}
 
-	data, err := json.Marshal(ev)
+	data, err := json.Marshal(payload)
 	if err != nil {
-		log.Printf("[Meta] Failed to marshal metadata change event: %v", err)
+		log.Printf("[Events] Failed to marshal event for %s: %v", subject, err)
 		return
 	}
 
 	if err := p.nc.Publish(subject, data); err != nil {
-		log.Printf("[Meta] Failed to publish metadata change event to %s: %v", subject, err)
+		log.Printf("[Events] Failed to publish event to %s: %v", subject, err)
 	}
 }
 

--- a/internal/core/store_traversal.go
+++ b/internal/core/store_traversal.go
@@ -159,6 +159,110 @@ func (s *Store) GetSubtree(assetID string, relTypes []RelationType, maxDepth int
 	return rootNode, nil
 }
 
+func (s *Store) FindLowestCommonAncestor(assetIDs []string, relTypes []RelationType, maxDepth int) (*AssetNode, error) {
+	if len(assetIDs) == 0 {
+		return nil, nil
+	}
+
+	var common map[string]lcaCandidate
+	for i, assetID := range assetIDs {
+		candidates, err := s.lcaCandidates(assetID, relTypes, maxDepth)
+		if err != nil {
+			return nil, err
+		}
+		if len(candidates) == 0 {
+			return nil, nil
+		}
+
+		if i == 0 {
+			common = candidates
+			continue
+		}
+
+		for id, current := range common {
+			next, ok := candidates[id]
+			if !ok {
+				delete(common, id)
+				continue
+			}
+			if next.depth > current.maxDepth {
+				current.maxDepth = next.depth
+			}
+			current.totalDepth += next.depth
+			common[id] = current
+		}
+		if len(common) == 0 {
+			return nil, nil
+		}
+	}
+
+	var selected *lcaCandidate
+	for _, candidate := range common {
+		candidate := candidate
+		if selected == nil ||
+			candidate.maxDepth < selected.maxDepth ||
+			(candidate.maxDepth == selected.maxDepth && candidate.totalDepth < selected.totalDepth) ||
+			(candidate.maxDepth == selected.maxDepth && candidate.totalDepth == selected.totalDepth && candidate.node.ID < selected.node.ID) {
+			selected = &candidate
+		}
+	}
+	if selected == nil {
+		return nil, nil
+	}
+	node := *selected.node
+	node.Depth = selected.maxDepth
+	return &node, nil
+}
+
+type lcaCandidate struct {
+	node       *AssetNode
+	depth      int
+	maxDepth   int
+	totalDepth int
+}
+
+func (s *Store) lcaCandidates(assetID string, relTypes []RelationType, maxDepth int) (map[string]lcaCandidate, error) {
+	asset, err := s.GetAsset(assetID)
+	if err != nil {
+		return nil, err
+	}
+	if asset == nil {
+		return map[string]lcaCandidate{}, nil
+	}
+
+	nodes := map[string]lcaCandidate{
+		asset.ID: {
+			node: &AssetNode{
+				ID:           asset.ID,
+				Name:         asset.Name,
+				TemplateName: asset.TemplateName,
+				Depth:        0,
+			},
+			depth:      0,
+			maxDepth:   0,
+			totalDepth: 0,
+		},
+	}
+
+	ancestors, err := s.GetAncestors(assetID, relTypes, maxDepth)
+	if err != nil {
+		return nil, err
+	}
+	for _, ancestor := range ancestors {
+		if existing, ok := nodes[ancestor.ID]; ok && existing.depth <= ancestor.Depth {
+			continue
+		}
+		node := *ancestor
+		nodes[ancestor.ID] = lcaCandidate{
+			node:       &node,
+			depth:      ancestor.Depth,
+			maxDepth:   ancestor.Depth,
+			totalDepth: ancestor.Depth,
+		}
+	}
+	return nodes, nil
+}
+
 func (s *Store) queryAssetNodes(query string, args ...any) ([]*AssetNode, error) {
 	rows, err := s.db.Query(query, args...)
 	if err != nil {


### PR DESCRIPTION
## Summary
- add alarm event types, impact computation, and grouped alarm publication
- add lowest-common-ancestor helper for grouping related alarm floods
- wire alarm settings and handler into core startup
- document alarm subjects and configuration

## Test
- go test ./...
- go vet ./...
- go test -race ./internal/core -run TestAlarmAggregator -count=1