### PR TITLE
feat: add template constraint validation (#86)

### DIFF
--- a/cmd/core/main.go
+++ b/cmd/core/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"flag"
 	"fmt"
 	"log"
@@ -26,6 +27,7 @@ func main() {
 	// Parse command-line flags
 	versionFlag := flag.Bool("version", false, "Print version information and exit")
 	migrateDownFlag := flag.Int("migrate-down", 0, "Rollback metadata DB by N migration steps and exit")
+	checkConstraintsFlag := flag.Bool("check-constraints", false, "Check catalog template constraints and exit")
 	configFlag := flag.String("config", os.Getenv("EDG_CORE_CONFIG"), "Path to core configuration file")
 	flag.Parse()
 
@@ -53,6 +55,20 @@ func main() {
 			log.Fatalf("Failed to rollback metadata DB: %v", err)
 		}
 		log.Printf("[Core] Rolled back metadata DB by %d migration step(s)", *migrateDownFlag)
+		os.Exit(0)
+	}
+
+	if *checkConstraintsFlag {
+		report, err := checkConstraints(cfg)
+		if err != nil {
+			log.Fatalf("Failed to check constraints: %v", err)
+		}
+		if err := json.NewEncoder(os.Stdout).Encode(report); err != nil {
+			log.Fatalf("Failed to write constraints report: %v", err)
+		}
+		if report.ViolationCount > 0 {
+			os.Exit(1)
+		}
 		os.Exit(0)
 	}
 
@@ -148,7 +164,10 @@ func main() {
 		RegistrationMode:  cfg.AssetRegistration.Mode,
 		Enricher:          enricher,
 	})
-	metaHandler := core.NewMetaHandler(store, loader, eventPublisher)
+	metaHandler := core.NewMetaHandlerWithOptions(store, loader, core.MetaHandlerOptions{
+		Events:                eventPublisher,
+		ConstraintEnforcement: cfg.Constraints.Enforcement,
+	})
 	alarmHandler := core.NewAlarmHandler(store, eventPublisher, core.AlarmHandlerOptions{
 		Window:            time.Duration(cfg.Alarm.WindowSeconds) * time.Second,
 		MaxTraversalDepth: cfg.Alarm.MaxTraversalDepth,
@@ -176,6 +195,21 @@ func main() {
 	log.Println("[Core] Shutting down...")
 	nc.Drain()
 	ns.Shutdown()
+}
+
+func checkConstraints(cfg core.CoreConfig) (core.ConstraintsReport, error) {
+	store, err := core.NewStoreWithMigrations(cfg.Storage.MetadataDB, cfg.Storage.AutoMigrate)
+	if err != nil {
+		return core.ConstraintsReport{}, err
+	}
+	defer store.Close()
+
+	loader := core.NewTemplateLoader()
+	if err := loader.LoadFromDir(cfg.Templates.Dir); err != nil {
+		return core.ConstraintsReport{}, err
+	}
+
+	return core.NewConstraintsEvaluator(loader).CheckAll(store)
 }
 
 func discoverConfigPath() string {

--- a/deploy/configs/core/config.dev.yaml
+++ b/deploy/configs/core/config.dev.yaml
@@ -25,6 +25,9 @@ alarm:
   window_seconds: 5
   max_traversal_depth: 10
 
+constraints:
+  enforcement: warn
+
 jetstream:
   validated_subject: platform.data.validated
   dead_letter_subject: platform.data.deadletter

--- a/deploy/configs/core/config.prod.yaml
+++ b/deploy/configs/core/config.prod.yaml
@@ -20,6 +20,9 @@ alarm:
   window_seconds: 5
   max_traversal_depth: 10
 
+constraints:
+  enforcement: warn
+
 jetstream:
   validated_subject: platform.data.validated
   dead_letter_subject: platform.data.deadletter

--- a/deploy/configs/core/config.staging.yaml
+++ b/deploy/configs/core/config.staging.yaml
@@ -20,6 +20,9 @@ alarm:
   window_seconds: 5
   max_traversal_depth: 10
 
+constraints:
+  enforcement: warn
+
 jetstream:
   validated_subject: platform.data.validated
   dead_letter_subject: platform.data.deadletter

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -237,6 +237,48 @@ If `relation_types` is omitted for tree traversal, core uses `partOf` and
 `locatedIn`. If `relation_type` is omitted for `connected`, core returns all
 one-hop relation types.
 
+### Template Constraints
+
+Templates can declare static relationship constraints. These constraints are
+checked after relation changes and by the catalog check subject.
+
+```yaml
+name: temp-sensor
+resources:
+  - name: temperature
+    valueType: NUMBER
+constraints:
+  required_relations:
+    - type: partOf
+      target_template: equipment
+      min: 1
+      max: 1
+  forbidden_relations:
+    - type: connectedTo
+      target_template: factory
+```
+
+`required_relations` counts outgoing relations from the asset to assets with the
+target template. `forbidden_relations` rejects any matching outgoing relation.
+If `min` is omitted for a required relation, the default is `1`; if `max` is
+omitted, there is no upper bound.
+
+The enforcement mode is configured in core YAML:
+
+```yaml
+constraints:
+  enforcement: warn # warn, enforce, or disabled
+```
+
+`warn` is the default and publishes `platform.meta.constraints.violation` while
+allowing the metadata write. `enforce` rejects the relation change and rolls it
+back. `disabled` skips constraint checks. To inspect the whole catalog, request
+`platform.meta.constraints.check` or run:
+
+```bash
+edg-core --check-constraints --config /opt/edg/config.yaml
+```
+
 ## Alarm Impact Analysis
 
 Adapters and internal components can raise alarms by publishing JSON to

--- a/internal/core/config.go
+++ b/internal/core/config.go
@@ -28,6 +28,7 @@ type CoreConfig struct {
 	JetStream         JetStreamConfig         `yaml:"jetstream"`
 	AssetRegistration AssetRegistrationConfig `yaml:"asset_registration"`
 	Alarm             AlarmConfig             `yaml:"alarm"`
+	Constraints       ConstraintsConfig       `yaml:"constraints"`
 }
 
 type NATSConfig struct {
@@ -67,6 +68,10 @@ type AssetRegistrationConfig struct {
 type AlarmConfig struct {
 	WindowSeconds     int `yaml:"window_seconds"`
 	MaxTraversalDepth int `yaml:"max_traversal_depth"`
+}
+
+type ConstraintsConfig struct {
+	Enforcement string `yaml:"enforcement"`
 }
 
 type JetStreamStreamConfig struct {
@@ -123,6 +128,9 @@ func DefaultCoreConfig() CoreConfig {
 		Alarm: AlarmConfig{
 			WindowSeconds:     int(DefaultAlarmWindow / time.Second),
 			MaxTraversalDepth: DefaultTraversalMaxDepth,
+		},
+		Constraints: ConstraintsConfig{
+			Enforcement: ConstraintsEnforcementWarn,
 		},
 	}
 }
@@ -186,6 +194,9 @@ func (c *CoreConfig) applyDefaults() {
 	if c.Alarm.MaxTraversalDepth == 0 {
 		c.Alarm.MaxTraversalDepth = defaults.Alarm.MaxTraversalDepth
 	}
+	if c.Constraints.Enforcement == "" {
+		c.Constraints.Enforcement = defaults.Constraints.Enforcement
+	}
 	c.JetStream.Stream.applyDefaults(defaults.JetStream.Stream)
 }
 
@@ -200,6 +211,11 @@ func (c CoreConfig) validate() error {
 	}
 	if c.Alarm.MaxTraversalDepth <= 0 {
 		return fmt.Errorf("invalid alarm.max_traversal_depth: %d (must be > 0)", c.Alarm.MaxTraversalDepth)
+	}
+	switch c.Constraints.Enforcement {
+	case ConstraintsEnforcementWarn, ConstraintsEnforcementEnforce, ConstraintsEnforcementDisabled:
+	default:
+		return fmt.Errorf("invalid constraints.enforcement: %q (allowed: warn, enforce, disabled)", c.Constraints.Enforcement)
 	}
 	return nil
 }

--- a/internal/core/config_test.go
+++ b/internal/core/config_test.go
@@ -39,6 +39,12 @@ func TestDefaultCoreConfig_Alarm(t *testing.T) {
 	assert.Equal(t, DefaultTraversalMaxDepth, cfg.Alarm.MaxTraversalDepth)
 }
 
+func TestDefaultCoreConfig_Constraints(t *testing.T) {
+	cfg := DefaultCoreConfig()
+
+	assert.Equal(t, ConstraintsEnforcementWarn, cfg.Constraints.Enforcement)
+}
+
 func TestLoadCoreConfig_JetStreamPolicyFromYAML(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "config.yaml")
 	err := os.WriteFile(path, []byte(`
@@ -121,6 +127,20 @@ alarm:
 	assert.Equal(t, 4, cfg.Alarm.MaxTraversalDepth)
 }
 
+func TestLoadCoreConfig_ConstraintsFromYAML(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	err := os.WriteFile(path, []byte(`
+constraints:
+  enforcement: enforce
+`), 0644)
+	require.NoError(t, err)
+
+	cfg, err := LoadCoreConfig(path)
+	require.NoError(t, err)
+
+	assert.Equal(t, ConstraintsEnforcementEnforce, cfg.Constraints.Enforcement)
+}
+
 func TestLoadCoreConfig_RejectsInvalidAssetRegistrationMode(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "config.yaml")
 	err := os.WriteFile(path, []byte(`
@@ -147,6 +167,20 @@ alarm:
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "invalid alarm.window_seconds")
+}
+
+func TestLoadCoreConfig_RejectsInvalidConstraintsEnforcement(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	err := os.WriteFile(path, []byte(`
+constraints:
+  enforcement: audit
+`), 0644)
+	require.NoError(t, err)
+
+	_, err = LoadCoreConfig(path)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid constraints.enforcement")
 }
 
 func TestJetStreamStreamConfig_NATSConfigRejectsInvalidPolicies(t *testing.T) {

--- a/internal/core/constraints.go
+++ b/internal/core/constraints.go
@@ -1,0 +1,239 @@
+package core
+
+import (
+	"fmt"
+	"strings"
+	"time"
+)
+
+const (
+	ConstraintRequiredRelation  = "required_relation"
+	ConstraintForbiddenRelation = "forbidden_relation"
+
+	ConstraintsEnforcementWarn     = "warn"
+	ConstraintsEnforcementEnforce  = "enforce"
+	ConstraintsEnforcementDisabled = "disabled"
+)
+
+type ConstraintViolation struct {
+	AssetID         string       `json:"asset_id"`
+	AssetName       string       `json:"asset_name,omitempty"`
+	TemplateName    string       `json:"template_name,omitempty"`
+	ConstraintType  string       `json:"constraint_type"`
+	RelationType    RelationType `json:"relation_type"`
+	TargetTemplate  string       `json:"target_template"`
+	ObservedCount   int          `json:"observed_count"`
+	ExpectedMin     *int         `json:"expected_min,omitempty"`
+	ExpectedMax     *int         `json:"expected_max,omitempty"`
+	Message         string       `json:"message"`
+	DetectedAt      time.Time    `json:"detected_at"`
+	EnforcementMode string       `json:"enforcement_mode,omitempty"`
+}
+
+type ConstraintsReport struct {
+	ViolationCount int                   `json:"violation_count"`
+	Violations     []ConstraintViolation `json:"violations"`
+	CheckedAt      time.Time             `json:"checked_at"`
+}
+
+type ConstraintsEvaluator struct {
+	loader *TemplateLoader
+}
+
+func NewConstraintsEvaluator(loader *TemplateLoader) *ConstraintsEvaluator {
+	return &ConstraintsEvaluator{loader: loader}
+}
+
+func (e *ConstraintsEvaluator) Check(asset *Asset, store *Store) ([]ConstraintViolation, error) {
+	if e == nil || e.loader == nil || store == nil || asset == nil || asset.TemplateName == "" {
+		return nil, nil
+	}
+	template := e.loader.Get(asset.TemplateName)
+	if template == nil {
+		return nil, nil
+	}
+
+	relations, err := store.GetRelationsBySourceAsset(asset.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	violations := []ConstraintViolation{}
+	for _, constraint := range template.Constraints.RequiredRelations {
+		count, err := countMatchingRelations(store, relations, constraint)
+		if err != nil {
+			return nil, err
+		}
+		min := constraint.MinValue(1)
+		max, hasMax := constraint.MaxValue()
+		if count < min {
+			violations = append(violations, newConstraintViolation(
+				asset,
+				ConstraintRequiredRelation,
+				constraint,
+				count,
+				&min,
+				maxPtrIf(hasMax, max),
+				fmt.Sprintf("asset %s requires at least %d %s relation(s) to template %s, found %d",
+					asset.ID, min, constraint.Type, constraint.TargetTemplate, count),
+			))
+		}
+		if hasMax && count > max {
+			violations = append(violations, newConstraintViolation(
+				asset,
+				ConstraintRequiredRelation,
+				constraint,
+				count,
+				&min,
+				&max,
+				fmt.Sprintf("asset %s allows at most %d %s relation(s) to template %s, found %d",
+					asset.ID, max, constraint.Type, constraint.TargetTemplate, count),
+			))
+		}
+	}
+
+	for _, constraint := range template.Constraints.ForbiddenRelations {
+		count, err := countMatchingRelations(store, relations, constraint)
+		if err != nil {
+			return nil, err
+		}
+		if count > 0 {
+			zero := 0
+			violations = append(violations, newConstraintViolation(
+				asset,
+				ConstraintForbiddenRelation,
+				constraint,
+				count,
+				nil,
+				&zero,
+				fmt.Sprintf("asset %s forbids %s relation(s) to template %s, found %d",
+					asset.ID, constraint.Type, constraint.TargetTemplate, count),
+			))
+		}
+	}
+
+	return violations, nil
+}
+
+func (e *ConstraintsEvaluator) CheckAll(store *Store) (ConstraintsReport, error) {
+	report := ConstraintsReport{CheckedAt: time.Now().UTC()}
+	if e == nil || store == nil {
+		return report, nil
+	}
+
+	assets, err := store.ListAssets()
+	if err != nil {
+		return report, err
+	}
+	for _, asset := range assets {
+		violations, err := e.Check(asset, store)
+		if err != nil {
+			return report, err
+		}
+		report.Violations = append(report.Violations, violations...)
+	}
+	report.ViolationCount = len(report.Violations)
+	return report, nil
+}
+
+func countMatchingRelations(store *Store, relations []*AssetRelation, constraint RelationConstraint) (int, error) {
+	count := 0
+	for _, relation := range relations {
+		if relation.RelationType != constraint.Type {
+			continue
+		}
+		target, err := store.GetAsset(relation.TargetAssetID)
+		if err != nil {
+			return 0, err
+		}
+		if target == nil {
+			continue
+		}
+		if constraint.TargetTemplate == "" || target.TemplateName == constraint.TargetTemplate {
+			count++
+		}
+	}
+	return count, nil
+}
+
+func newConstraintViolation(asset *Asset, constraintType string, constraint RelationConstraint, count int, min, max *int, message string) ConstraintViolation {
+	return ConstraintViolation{
+		AssetID:        asset.ID,
+		AssetName:      asset.Name,
+		TemplateName:   asset.TemplateName,
+		ConstraintType: constraintType,
+		RelationType:   constraint.Type,
+		TargetTemplate: constraint.TargetTemplate,
+		ObservedCount:  count,
+		ExpectedMin:    min,
+		ExpectedMax:    max,
+		Message:        message,
+		DetectedAt:     time.Now().UTC(),
+	}
+}
+
+func maxPtrIf(ok bool, value int) *int {
+	if !ok {
+		return nil
+	}
+	return &value
+}
+
+func (c RelationConstraint) MinValue(defaultValue int) int {
+	if c.Min == nil {
+		return defaultValue
+	}
+	return *c.Min
+}
+
+func (c RelationConstraint) MaxValue() (int, bool) {
+	if c.Max == nil {
+		return 0, false
+	}
+	return *c.Max, true
+}
+
+func validateTemplateConstraints(loader *TemplateLoader) error {
+	if loader == nil {
+		return nil
+	}
+	for _, template := range loader.List() {
+		constraints := append([]RelationConstraint{}, template.Constraints.RequiredRelations...)
+		constraints = append(constraints, template.Constraints.ForbiddenRelations...)
+		for _, constraint := range constraints {
+			if constraint.Type == "" {
+				return fmt.Errorf("template %s constraint relation type is required", template.Name)
+			}
+			if !IsValidRelationType(constraint.Type) {
+				return fmt.Errorf("template %s constraint has invalid relation type: %s", template.Name, constraint.Type)
+			}
+			if constraint.TargetTemplate == "" {
+				return fmt.Errorf("template %s constraint target_template is required", template.Name)
+			}
+			if !loader.Exists(constraint.TargetTemplate) {
+				return fmt.Errorf("template %s constraint references unknown target_template: %s", template.Name, constraint.TargetTemplate)
+			}
+			if constraint.Min != nil && *constraint.Min < 0 {
+				return fmt.Errorf("template %s constraint min must be >= 0", template.Name)
+			}
+			if constraint.Max != nil && *constraint.Max < 0 {
+				return fmt.Errorf("template %s constraint max must be >= 0", template.Name)
+			}
+			if constraint.Min != nil && constraint.Max != nil && *constraint.Min > *constraint.Max {
+				return fmt.Errorf("template %s constraint min cannot exceed max", template.Name)
+			}
+		}
+	}
+	return nil
+}
+
+func constraintsViolationError(violations []ConstraintViolation) string {
+	if len(violations) == 0 {
+		return ""
+	}
+	messages := make([]string, 0, len(violations))
+	for _, violation := range violations {
+		messages = append(messages, violation.Message)
+	}
+	return "constraint violation: " + strings.Join(messages, "; ")
+}

--- a/internal/core/constraints_test.go
+++ b/internal/core/constraints_test.go
@@ -1,0 +1,171 @@
+package core
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/nats-io/nats.go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConstraintsEvaluator_CheckRequiredAndForbiddenRelations(t *testing.T) {
+	store, loader := newConstraintTestStore(t)
+	evaluator := NewConstraintsEvaluator(loader)
+
+	sensor, err := store.GetAsset("sensor-1")
+	require.NoError(t, err)
+
+	violations, err := evaluator.Check(sensor, store)
+	require.NoError(t, err)
+	require.Len(t, violations, 1)
+	assert.Equal(t, ConstraintRequiredRelation, violations[0].ConstraintType)
+	assert.Equal(t, RelationPartOf, violations[0].RelationType)
+	assert.Equal(t, "equipment", violations[0].TargetTemplate)
+
+	createTraversalRelation(t, store, "rel-sensor-equipment", "sensor-1", "equipment-1", RelationPartOf)
+
+	violations, err = evaluator.Check(sensor, store)
+	require.NoError(t, err)
+	assert.Empty(t, violations)
+
+	createTraversalRelation(t, store, "rel-sensor-factory", "sensor-1", "factory-1", RelationConnectedTo)
+
+	violations, err = evaluator.Check(sensor, store)
+	require.NoError(t, err)
+	require.Len(t, violations, 1)
+	assert.Equal(t, ConstraintForbiddenRelation, violations[0].ConstraintType)
+	assert.Equal(t, RelationConnectedTo, violations[0].RelationType)
+	assert.Equal(t, "factory", violations[0].TargetTemplate)
+}
+
+func TestMetaHandler_RelationCreateEnforceRejectsAndRollsBackConstraintViolation(t *testing.T) {
+	_, nc, _ := startTestNATSServer(t, false)
+	store, loader := newConstraintTestStore(t)
+
+	handler := NewMetaHandlerWithOptions(store, loader, MetaHandlerOptions{
+		Events:                NewEventPublisher(nc),
+		ConstraintEnforcement: ConstraintsEnforcementEnforce,
+	})
+	require.NoError(t, handler.RegisterHandlers(nc))
+	require.NoError(t, nc.Flush())
+
+	resp := requestMeta(t, nc, SubjectRelationCreate, CreateRelationRequest{
+		SourceAssetID: "sensor-1",
+		TargetAssetID: "factory-1",
+		RelationType:  RelationPartOf,
+	})
+
+	require.False(t, resp.Success)
+	assert.Contains(t, resp.Error, "constraint violation")
+
+	relations, err := store.GetRelationsBySourceAsset("sensor-1")
+	require.NoError(t, err)
+	assert.Empty(t, relations)
+}
+
+func TestMetaHandler_RelationCreateWarnPublishesViolationAndAllows(t *testing.T) {
+	_, nc, _ := startTestNATSServer(t, false)
+	store, loader := newConstraintTestStore(t)
+	violations := subscribeConstraintViolations(t, nc)
+
+	handler := NewMetaHandlerWithOptions(store, loader, MetaHandlerOptions{
+		Events:                NewEventPublisher(nc),
+		ConstraintEnforcement: ConstraintsEnforcementWarn,
+	})
+	require.NoError(t, handler.RegisterHandlers(nc))
+	require.NoError(t, nc.Flush())
+
+	resp := requestMeta(t, nc, SubjectRelationCreate, CreateRelationRequest{
+		SourceAssetID: "sensor-1",
+		TargetAssetID: "factory-1",
+		RelationType:  RelationPartOf,
+	})
+
+	require.True(t, resp.Success, resp.Error)
+	violation := requireConstraintViolation(t, violations)
+	assert.Equal(t, "sensor-1", violation.AssetID)
+	assert.Equal(t, ConstraintRequiredRelation, violation.ConstraintType)
+}
+
+func TestMetaHandler_ConstraintsCheckReportsCatalogViolations(t *testing.T) {
+	_, nc, _ := startTestNATSServer(t, false)
+	store, loader := newConstraintTestStore(t)
+
+	handler := NewMetaHandlerWithOptions(store, loader, MetaHandlerOptions{
+		ConstraintEnforcement: ConstraintsEnforcementWarn,
+	})
+	require.NoError(t, handler.RegisterHandlers(nc))
+	require.NoError(t, nc.Flush())
+
+	resp := requestMeta(t, nc, SubjectConstraintsCheck, map[string]string{})
+	require.True(t, resp.Success, resp.Error)
+
+	var report ConstraintsReport
+	require.NoError(t, json.Unmarshal(resp.Data, &report))
+	assert.Equal(t, 1, report.ViolationCount)
+	require.Len(t, report.Violations, 1)
+	assert.Equal(t, "sensor-1", report.Violations[0].AssetID)
+}
+
+func subscribeConstraintViolations(t *testing.T, nc *nats.Conn) chan ConstraintViolation {
+	t.Helper()
+
+	ch := make(chan ConstraintViolation, 4)
+	sub, err := nc.Subscribe(SubjectConstraintsViolation, func(msg *nats.Msg) {
+		var violation ConstraintViolation
+		if err := json.Unmarshal(msg.Data, &violation); err == nil {
+			ch <- violation
+		}
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = sub.Unsubscribe()
+	})
+	require.NoError(t, nc.Flush())
+	return ch
+}
+
+func requireConstraintViolation(t *testing.T, ch <-chan ConstraintViolation) ConstraintViolation {
+	t.Helper()
+
+	select {
+	case violation := <-ch:
+		return violation
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for constraint violation")
+		return ConstraintViolation{}
+	}
+}
+
+func newConstraintTestStore(t *testing.T) (*Store, *TemplateLoader) {
+	t.Helper()
+
+	store, err := NewStore(":memory:")
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, store.Close())
+	})
+
+	createTraversalAsset(t, store, "sensor-1", "Sensor 1", "sensor")
+	createTraversalAsset(t, store, "equipment-1", "Equipment 1", "equipment")
+	createTraversalAsset(t, store, "factory-1", "Factory 1", "factory")
+
+	one := 1
+	loader := NewTemplateLoader()
+	loader.templates["sensor"] = &AssetTemplate{
+		Name: "sensor",
+		Constraints: TemplateConstraints{
+			RequiredRelations: []RelationConstraint{
+				{Type: RelationPartOf, TargetTemplate: "equipment", Min: &one, Max: &one},
+			},
+			ForbiddenRelations: []RelationConstraint{
+				{Type: RelationConnectedTo, TargetTemplate: "factory"},
+			},
+		},
+	}
+	loader.templates["equipment"] = &AssetTemplate{Name: "equipment"}
+	loader.templates["factory"] = &AssetTemplate{Name: "factory"}
+	return store, loader
+}

--- a/internal/core/events.go
+++ b/internal/core/events.go
@@ -21,6 +21,8 @@ const (
 	SubjectAlarmImpactComputed = "platform.alarm.impact.computed"
 	SubjectAlarmGrouped        = "platform.alarm.grouped"
 
+	SubjectConstraintsViolation = "platform.meta.constraints.violation"
+
 	EventSchemaVersion = 1
 )
 
@@ -72,6 +74,10 @@ func (p *EventPublisher) PublishAlarmImpactComputed(impact AlarmImpact) {
 
 func (p *EventPublisher) PublishAlarmGrouped(group AlarmGroup) {
 	p.publishJSON(SubjectAlarmGrouped, group)
+}
+
+func (p *EventPublisher) PublishConstraintViolation(violation ConstraintViolation) {
+	p.publishJSON(SubjectConstraintsViolation, violation)
 }
 
 func (p *EventPublisher) publishMetaChange(subject string, ev MetaChangeEvent) {

--- a/internal/core/loader.go
+++ b/internal/core/loader.go
@@ -45,7 +45,7 @@ func (l *TemplateLoader) LoadFromDir(dir string) error {
 		}
 	}
 
-	return nil
+	return validateTemplateConstraints(l)
 }
 
 // LoadFromFile loads a template from a single YAML file

--- a/internal/core/loader_test.go
+++ b/internal/core/loader_test.go
@@ -29,6 +29,9 @@ func TestLoadFromFile_Success(t *testing.T) {
 	assert.Equal(t, ValueTypeText, template.Resources[1].ValueType)
 	assert.Equal(t, "enabled", template.Resources[2].Name)
 	assert.Equal(t, ValueTypeFlag, template.Resources[2].ValueType)
+	require.Len(t, template.Constraints.RequiredRelations, 1)
+	assert.Equal(t, RelationPartOf, template.Constraints.RequiredRelations[0].Type)
+	assert.Equal(t, "equipment", template.Constraints.RequiredRelations[0].TargetTemplate)
 }
 
 // TestLoadFromFile_InvalidYAML tests handling of malformed YAML
@@ -64,6 +67,25 @@ func TestLoadFromDir_FailsOnInvalidFile(t *testing.T) {
 	err := loader.LoadFromDir("testdata")
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "template name is missing")
+}
+
+func TestLoadFromDir_FailsOnUnknownConstraintTargetTemplate(t *testing.T) {
+	loader := NewTemplateLoader()
+	tmpDir := t.TempDir()
+	err := os.WriteFile(filepath.Join(tmpDir, "sensor.yaml"), []byte(`
+name: sensor
+resources: []
+constraints:
+  required_relations:
+    - type: partOf
+      target_template: missing-template
+`), 0644)
+	require.NoError(t, err)
+
+	err = loader.LoadFromDir(tmpDir)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown target_template")
 }
 
 // TestValidateAssetData_Success tests successful data validation

--- a/internal/core/meta_handler.go
+++ b/internal/core/meta_handler.go
@@ -11,12 +11,13 @@ import (
 
 // NATS subjects
 const (
-	SubjectAssetCreate  = "platform.meta.asset.create"
-	SubjectAssetGet     = "platform.meta.asset.get"
-	SubjectAssetList    = "platform.meta.asset.list"
-	SubjectAssetUpdate  = "platform.meta.asset.update"
-	SubjectAssetDelete  = "platform.meta.asset.delete"
-	SubjectTemplateList = "platform.meta.template.list"
+	SubjectAssetCreate      = "platform.meta.asset.create"
+	SubjectAssetGet         = "platform.meta.asset.get"
+	SubjectAssetList        = "platform.meta.asset.list"
+	SubjectAssetUpdate      = "platform.meta.asset.update"
+	SubjectAssetDelete      = "platform.meta.asset.delete"
+	SubjectTemplateList     = "platform.meta.template.list"
+	SubjectConstraintsCheck = "platform.meta.constraints.check"
 
 	// Relation subjects
 	SubjectRelationCreate = "platform.meta.relation.create"
@@ -27,9 +28,16 @@ const (
 
 // MetaHandler handles metadata NATS messages
 type MetaHandler struct {
-	store  *Store
-	loader *TemplateLoader
-	events *EventPublisher
+	store                 *Store
+	loader                *TemplateLoader
+	events                *EventPublisher
+	constraints           *ConstraintsEvaluator
+	constraintEnforcement string
+}
+
+type MetaHandlerOptions struct {
+	Events                *EventPublisher
+	ConstraintEnforcement string
 }
 
 // NewMetaHandler creates a new handler
@@ -38,22 +46,36 @@ func NewMetaHandler(store *Store, loader *TemplateLoader, events ...*EventPublis
 	if len(events) > 0 {
 		publisher = events[0]
 	}
+	return NewMetaHandlerWithOptions(store, loader, MetaHandlerOptions{
+		Events:                publisher,
+		ConstraintEnforcement: ConstraintsEnforcementWarn,
+	})
+}
+
+func NewMetaHandlerWithOptions(store *Store, loader *TemplateLoader, opts MetaHandlerOptions) *MetaHandler {
+	enforcement := opts.ConstraintEnforcement
+	if enforcement == "" {
+		enforcement = ConstraintsEnforcementWarn
+	}
 	return &MetaHandler{
-		store:  store,
-		loader: loader,
-		events: publisher,
+		store:                 store,
+		loader:                loader,
+		events:                opts.Events,
+		constraints:           NewConstraintsEvaluator(loader),
+		constraintEnforcement: enforcement,
 	}
 }
 
 // RegisterHandlers registers NATS subscriptions
 func (h *MetaHandler) RegisterHandlers(nc *nats.Conn) error {
 	handlers := map[string]nats.MsgHandler{
-		SubjectAssetCreate:  h.handleAssetCreate,
-		SubjectAssetGet:     h.handleAssetGet,
-		SubjectAssetList:    h.handleAssetList,
-		SubjectAssetUpdate:  h.handleAssetUpdate,
-		SubjectAssetDelete:  h.handleAssetDelete,
-		SubjectTemplateList: h.handleTemplateList,
+		SubjectAssetCreate:      h.handleAssetCreate,
+		SubjectAssetGet:         h.handleAssetGet,
+		SubjectAssetList:        h.handleAssetList,
+		SubjectAssetUpdate:      h.handleAssetUpdate,
+		SubjectAssetDelete:      h.handleAssetDelete,
+		SubjectTemplateList:     h.handleTemplateList,
+		SubjectConstraintsCheck: h.handleConstraintsCheck,
 
 		// Relation handlers
 		SubjectRelationCreate: h.handleRelationCreate,
@@ -437,6 +459,56 @@ func traversalRelationTypesOrDefault(relTypes []RelationType) []RelationType {
 	return relTypes
 }
 
+func (h *MetaHandler) handleConstraintsCheck(msg *nats.Msg) {
+	report, err := h.constraints.CheckAll(h.store)
+	if err != nil {
+		h.reply(msg, Response{Success: false, Error: err.Error()})
+		return
+	}
+	h.reply(msg, Response{Success: true, Data: report})
+}
+
+func (h *MetaHandler) checkRelationConstraints(relation *AssetRelation) ([]ConstraintViolation, error) {
+	if h == nil || h.constraintEnforcement == ConstraintsEnforcementDisabled || h.constraints == nil || relation == nil {
+		return nil, nil
+	}
+
+	assetIDs := []string{relation.SourceAssetID, relation.TargetAssetID}
+	seen := map[string]bool{}
+	var violations []ConstraintViolation
+	for _, assetID := range assetIDs {
+		if seen[assetID] {
+			continue
+		}
+		seen[assetID] = true
+		asset, err := h.store.GetAsset(assetID)
+		if err != nil {
+			return nil, err
+		}
+		if asset == nil {
+			continue
+		}
+		assetViolations, err := h.constraints.Check(asset, h.store)
+		if err != nil {
+			return nil, err
+		}
+		violations = append(violations, assetViolations...)
+	}
+	return violations, nil
+}
+
+func (h *MetaHandler) allowConstraintViolations(violations []ConstraintViolation) bool {
+	if len(violations) == 0 || h.constraintEnforcement == ConstraintsEnforcementDisabled {
+		return true
+	}
+	for _, violation := range violations {
+		violation.EnforcementMode = h.constraintEnforcement
+		h.events.PublishConstraintViolation(violation)
+		log.Printf("[Meta] Constraint violation: %s", violation.Message)
+	}
+	return h.constraintEnforcement != ConstraintsEnforcementEnforce
+}
+
 // ==================== AssetRelation Handlers ====================
 
 // CreateRelationRequest is a request to create a relation
@@ -487,6 +559,16 @@ func (h *MetaHandler) handleRelationCreate(msg *nats.Msg) {
 
 	if err := h.store.CreateRelation(relation); err != nil {
 		h.reply(msg, Response{Success: false, Error: err.Error()})
+		return
+	}
+
+	if violations, err := h.checkRelationConstraints(relation); err != nil {
+		_ = h.store.DeleteRelation(relation.ID)
+		h.reply(msg, Response{Success: false, Error: err.Error()})
+		return
+	} else if !h.allowConstraintViolations(violations) {
+		_ = h.store.DeleteRelation(relation.ID)
+		h.reply(msg, Response{Success: false, Error: constraintsViolationError(violations)})
 		return
 	}
 

--- a/internal/core/metadata.go
+++ b/internal/core/metadata.go
@@ -22,8 +22,9 @@ const (
 
 // AssetTemplate defines an asset type loaded from YAML
 type AssetTemplate struct {
-	Name      string          `yaml:"name" json:"name"`
-	Resources []AssetResource `yaml:"resources" json:"resources"`
+	Name        string              `yaml:"name" json:"name"`
+	Resources   []AssetResource     `yaml:"resources" json:"resources"`
+	Constraints TemplateConstraints `yaml:"constraints,omitempty" json:"constraints,omitempty"`
 }
 
 // AssetResource defines a data point provided by an asset
@@ -39,3 +40,17 @@ const (
 	ValueTypeText   = "TEXT"
 	ValueTypeFlag   = "FLAG"
 )
+
+// TemplateConstraints defines static relationship constraints for an asset type.
+type TemplateConstraints struct {
+	RequiredRelations  []RelationConstraint `yaml:"required_relations,omitempty" json:"required_relations,omitempty"`
+	ForbiddenRelations []RelationConstraint `yaml:"forbidden_relations,omitempty" json:"forbidden_relations,omitempty"`
+}
+
+// RelationConstraint describes a relation type and target template cardinality.
+type RelationConstraint struct {
+	Type           RelationType `yaml:"type" json:"type"`
+	TargetTemplate string       `yaml:"target_template" json:"target_template"`
+	Min            *int         `yaml:"min,omitempty" json:"min,omitempty"`
+	Max            *int         `yaml:"max,omitempty" json:"max,omitempty"`
+}

--- a/internal/core/testdata/valid_template.yaml
+++ b/internal/core/testdata/valid_template.yaml
@@ -8,3 +8,9 @@ resources:
     valueType: TEXT
   - name: enabled
     valueType: FLAG
+constraints:
+  required_relations:
+    - type: partOf
+      target_template: equipment
+      min: 1
+      max: 1

--- a/templates/equipment.yaml
+++ b/templates/equipment.yaml
@@ -1,0 +1,2 @@
+name: equipment
+resources: []

--- a/templates/temp-sensor.yaml
+++ b/templates/temp-sensor.yaml
@@ -6,3 +6,9 @@ resources:
   - name: humidity
     valueType: NUMBER
     unit: "%"
+constraints:
+  required_relations:
+    - type: partOf
+      target_template: equipment
+      min: 1
+      max: 1

--- a/templates/vibration-sensor.yaml
+++ b/templates/vibration-sensor.yaml
@@ -11,3 +11,9 @@ resources:
     unit: "μm"
   - name: alarm
     valueType: FLAG
+constraints:
+  required_relations:
+    - type: partOf
+      target_template: equipment
+      min: 1
+      max: 1


### PR DESCRIPTION
## Summary
- extend templates with relationship constraints
- add constraint evaluator, violation events, and catalog check subject/CLI
- enforce or warn on relation-create violations with rollback in enforce mode
- document template constraints and add example constraints

## Test
- go test ./...
- go vet ./...
- go run ./cmd/core --check-constraints --config deploy/configs/core/config.dev.yaml