### PR TITLE
feat: add read-only HTTP metadata API (#88)

### DIFF
--- a/cmd/core/main.go
+++ b/cmd/core/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"flag"
 	"fmt"
@@ -14,6 +15,7 @@ import (
 	"github.com/nats-io/nats.go"
 
 	"github.com/e7217/edg/internal/core"
+	"github.com/e7217/edg/internal/httpapi"
 )
 
 var (
@@ -172,6 +174,25 @@ func main() {
 		Window:            time.Duration(cfg.Alarm.WindowSeconds) * time.Second,
 		MaxTraversalDepth: cfg.Alarm.MaxTraversalDepth,
 	})
+	serviceCtx, stopServices := context.WithCancel(context.Background())
+	defer stopServices()
+
+	if cfg.HTTP.Enabled {
+		httpServer := httpapi.NewServer(store, httpapi.Options{
+			Address:            cfg.HTTP.Address,
+			TokenEnv:           cfg.HTTP.TokenEnv,
+			CORSAllowedOrigins: cfg.HTTP.CORSAllowedOrigins,
+			Version:            Version,
+			BuildTime:          BuildTime,
+			GitCommit:          GitCommit,
+		})
+		go func() {
+			log.Printf("[Core] HTTP API listening on http://%s", cfg.HTTP.Address)
+			if err := httpServer.Run(serviceCtx); err != nil {
+				log.Printf("[Core] HTTP API stopped: %v", err)
+			}
+		}()
+	}
 
 	_, err = nc.Subscribe("platform.data.asset", dataHandler.HandleAssetData)
 	if err != nil {
@@ -193,6 +214,7 @@ func main() {
 	<-quit
 
 	log.Println("[Core] Shutting down...")
+	stopServices()
 	nc.Drain()
 	ns.Shutdown()
 }

--- a/deploy/configs/core/config.dev.yaml
+++ b/deploy/configs/core/config.dev.yaml
@@ -28,6 +28,13 @@ alarm:
 constraints:
   enforcement: warn
 
+http:
+  enabled: true
+  address: 127.0.0.1:8080
+  token_env: EDG_HTTP_TOKEN
+  cors_allowed_origins:
+    - http://localhost:3000
+
 jetstream:
   validated_subject: platform.data.validated
   dead_letter_subject: platform.data.deadletter

--- a/deploy/configs/core/config.prod.yaml
+++ b/deploy/configs/core/config.prod.yaml
@@ -23,6 +23,11 @@ alarm:
 constraints:
   enforcement: warn
 
+http:
+  enabled: false
+  address: 127.0.0.1:8080
+  token_env: EDG_HTTP_TOKEN
+
 jetstream:
   validated_subject: platform.data.validated
   dead_letter_subject: platform.data.deadletter

--- a/deploy/configs/core/config.staging.yaml
+++ b/deploy/configs/core/config.staging.yaml
@@ -23,6 +23,11 @@ alarm:
 constraints:
   enforcement: warn
 
+http:
+  enabled: false
+  address: 127.0.0.1:8080
+  token_env: EDG_HTTP_TOKEN
+
 jetstream:
   validated_subject: platform.data.validated
   dead_letter_subject: platform.data.deadletter

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -313,6 +313,51 @@ The in-memory window is intentionally short-lived. If the core process restarts,
 pending groups that have not yet been emitted are lost; durable alarm history is
 outside this PoC scope.
 
+## HTTP Metadata API
+
+EDG Core can expose a read-only HTTP API for browser dashboards and operator
+tools. It is disabled by default outside the development config.
+
+```yaml
+http:
+  enabled: true
+  address: 127.0.0.1:8080
+  token_env: EDG_HTTP_TOKEN
+  cors_allowed_origins:
+    - http://localhost:3000
+```
+
+If the environment variable named by `token_env` contains a value, requests must
+include `Authorization: Bearer <token>`. If the variable is unset, the API is
+anonymous and should remain bound to localhost.
+
+All responses use the same envelope as NATS metadata replies:
+
+```json
+{"success": true, "data": {}}
+```
+
+Available endpoints:
+
+| Method | Path | Notes |
+|---|---|---|
+| `GET` | `/api/v1/health` | Process health. |
+| `GET` | `/api/v1/version` | Build version metadata. |
+| `GET` | `/api/v1/assets?limit=100&offset=0` | List assets. |
+| `GET` | `/api/v1/assets/{id}` | Get one asset. |
+| `GET` | `/api/v1/assets/{id}/ancestors?relation_types=partOf,locatedIn&max_depth=10` | Traverse parents. |
+| `GET` | `/api/v1/assets/{id}/descendants?relation_types=partOf&max_depth=10` | Traverse children. |
+| `GET` | `/api/v1/assets/{id}/subtree?relation_types=partOf&max_depth=10` | Recursive tree. |
+| `GET` | `/api/v1/assets/{id}/connected?relation_type=connectedTo` | One-hop relation query. |
+| `GET` | `/api/v1/relations?source=&target=&type=` | List and filter relations. |
+
+Example:
+
+```bash
+curl -H "Authorization: Bearer $EDG_HTTP_TOKEN" \
+  "http://127.0.0.1:8080/api/v1/assets/factory-1/descendants?relation_types=partOf&max_depth=10"
+```
+
 ## Monitoring
 
 - **NATS Monitor**: http://localhost:8222

--- a/internal/core/config.go
+++ b/internal/core/config.go
@@ -29,6 +29,7 @@ type CoreConfig struct {
 	AssetRegistration AssetRegistrationConfig `yaml:"asset_registration"`
 	Alarm             AlarmConfig             `yaml:"alarm"`
 	Constraints       ConstraintsConfig       `yaml:"constraints"`
+	HTTP              HTTPConfig              `yaml:"http"`
 }
 
 type NATSConfig struct {
@@ -72,6 +73,13 @@ type AlarmConfig struct {
 
 type ConstraintsConfig struct {
 	Enforcement string `yaml:"enforcement"`
+}
+
+type HTTPConfig struct {
+	Enabled            bool     `yaml:"enabled"`
+	Address            string   `yaml:"address"`
+	TokenEnv           string   `yaml:"token_env"`
+	CORSAllowedOrigins []string `yaml:"cors_allowed_origins"`
 }
 
 type JetStreamStreamConfig struct {
@@ -131,6 +139,11 @@ func DefaultCoreConfig() CoreConfig {
 		},
 		Constraints: ConstraintsConfig{
 			Enforcement: ConstraintsEnforcementWarn,
+		},
+		HTTP: HTTPConfig{
+			Enabled:  false,
+			Address:  "127.0.0.1:8080",
+			TokenEnv: "EDG_HTTP_TOKEN",
 		},
 	}
 }
@@ -197,6 +210,12 @@ func (c *CoreConfig) applyDefaults() {
 	if c.Constraints.Enforcement == "" {
 		c.Constraints.Enforcement = defaults.Constraints.Enforcement
 	}
+	if c.HTTP.Address == "" {
+		c.HTTP.Address = defaults.HTTP.Address
+	}
+	if c.HTTP.TokenEnv == "" {
+		c.HTTP.TokenEnv = defaults.HTTP.TokenEnv
+	}
 	c.JetStream.Stream.applyDefaults(defaults.JetStream.Stream)
 }
 
@@ -216,6 +235,9 @@ func (c CoreConfig) validate() error {
 	case ConstraintsEnforcementWarn, ConstraintsEnforcementEnforce, ConstraintsEnforcementDisabled:
 	default:
 		return fmt.Errorf("invalid constraints.enforcement: %q (allowed: warn, enforce, disabled)", c.Constraints.Enforcement)
+	}
+	if c.HTTP.Enabled && c.HTTP.Address == "" {
+		return fmt.Errorf("http.address is required when http.enabled is true")
 	}
 	return nil
 }

--- a/internal/core/config_test.go
+++ b/internal/core/config_test.go
@@ -45,6 +45,14 @@ func TestDefaultCoreConfig_Constraints(t *testing.T) {
 	assert.Equal(t, ConstraintsEnforcementWarn, cfg.Constraints.Enforcement)
 }
 
+func TestDefaultCoreConfig_HTTP(t *testing.T) {
+	cfg := DefaultCoreConfig()
+
+	assert.False(t, cfg.HTTP.Enabled)
+	assert.Equal(t, "127.0.0.1:8080", cfg.HTTP.Address)
+	assert.Equal(t, "EDG_HTTP_TOKEN", cfg.HTTP.TokenEnv)
+}
+
 func TestLoadCoreConfig_JetStreamPolicyFromYAML(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "config.yaml")
 	err := os.WriteFile(path, []byte(`
@@ -139,6 +147,27 @@ constraints:
 	require.NoError(t, err)
 
 	assert.Equal(t, ConstraintsEnforcementEnforce, cfg.Constraints.Enforcement)
+}
+
+func TestLoadCoreConfig_HTTPFromYAML(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	err := os.WriteFile(path, []byte(`
+http:
+  enabled: true
+  address: 127.0.0.1:9090
+  token_env: CUSTOM_HTTP_TOKEN
+  cors_allowed_origins:
+    - http://localhost:3000
+`), 0644)
+	require.NoError(t, err)
+
+	cfg, err := LoadCoreConfig(path)
+	require.NoError(t, err)
+
+	assert.True(t, cfg.HTTP.Enabled)
+	assert.Equal(t, "127.0.0.1:9090", cfg.HTTP.Address)
+	assert.Equal(t, "CUSTOM_HTTP_TOKEN", cfg.HTTP.TokenEnv)
+	assert.Equal(t, []string{"http://localhost:3000"}, cfg.HTTP.CORSAllowedOrigins)
 }
 
 func TestLoadCoreConfig_RejectsInvalidAssetRegistrationMode(t *testing.T) {

--- a/internal/core/store.go
+++ b/internal/core/store.go
@@ -461,6 +461,42 @@ func (s *Store) GetRelation(id string) (*AssetRelation, error) {
 	return &relation, nil
 }
 
+// ListRelations retrieves all asset relations.
+func (s *Store) ListRelations() ([]*AssetRelation, error) {
+	rows, err := s.db.Query(
+		`SELECT id, source_asset_id, target_asset_id, relation_type, created_at, metadata
+		 FROM asset_relations ORDER BY created_at DESC`,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query relations: %w", err)
+	}
+	defer rows.Close()
+
+	var relations []*AssetRelation
+	for rows.Next() {
+		var relation AssetRelation
+		var metadataJSON sql.NullString
+		if err := rows.Scan(
+			&relation.ID, &relation.SourceAssetID, &relation.TargetAssetID,
+			&relation.RelationType, &relation.CreatedAt, &metadataJSON,
+		); err != nil {
+			return nil, err
+		}
+
+		if metadataJSON.Valid && metadataJSON.String != "" {
+			if err := json.Unmarshal([]byte(metadataJSON.String), &relation.Metadata); err != nil {
+				return nil, fmt.Errorf("failed to unmarshal relation metadata: %w", err)
+			}
+		}
+
+		relations = append(relations, &relation)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("failed to iterate relations: %w", err)
+	}
+	return relations, nil
+}
+
 // GetRelationsBySourceAsset retrieves all relations from a source asset
 func (s *Store) GetRelationsBySourceAsset(assetID string) ([]*AssetRelation, error) {
 	rows, err := s.db.Query(

--- a/internal/httpapi/response.go
+++ b/internal/httpapi/response.go
@@ -1,0 +1,24 @@
+package httpapi
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/e7217/edg/internal/core"
+)
+
+func writeResponse(w http.ResponseWriter, status int, data any) {
+	writeJSON(w, status, core.Response{Success: true, Data: data})
+}
+
+func writeError(w http.ResponseWriter, status int, message string) {
+	writeJSON(w, status, core.Response{Success: false, Error: message})
+}
+
+func writeJSON(w http.ResponseWriter, status int, resp core.Response) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	if err := json.NewEncoder(w).Encode(resp); err != nil {
+		http.Error(w, `{"success":false,"error":"failed to encode response"}`, http.StatusInternalServerError)
+	}
+}

--- a/internal/httpapi/server.go
+++ b/internal/httpapi/server.go
@@ -1,0 +1,371 @@
+package httpapi
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/e7217/edg/internal/core"
+)
+
+const (
+	defaultAddress  = "127.0.0.1:8080"
+	defaultTokenEnv = "EDG_HTTP_TOKEN"
+)
+
+type Options struct {
+	Address            string
+	Token              string
+	TokenEnv           string
+	CORSAllowedOrigins []string
+	Version            string
+	BuildTime          string
+	GitCommit          string
+}
+
+type Server struct {
+	store   *core.Store
+	options Options
+	handler http.Handler
+}
+
+func NewServer(store *core.Store, opts Options) *Server {
+	if opts.Address == "" {
+		opts.Address = defaultAddress
+	}
+	if opts.TokenEnv == "" {
+		opts.TokenEnv = defaultTokenEnv
+	}
+	if opts.Token == "" && opts.TokenEnv != "" {
+		opts.Token = os.Getenv(opts.TokenEnv)
+	}
+	server := &Server{
+		store:   store,
+		options: opts,
+	}
+	server.handler = server.buildHandler()
+	return server
+}
+
+func (s *Server) Handler() http.Handler {
+	return s.handler
+}
+
+func (s *Server) Run(ctx context.Context) error {
+	httpServer := &http.Server{
+		Addr:              s.options.Address,
+		Handler:           s.handler,
+		ReadHeaderTimeout: 5 * time.Second,
+	}
+
+	errCh := make(chan error, 1)
+	go func() {
+		err := httpServer.ListenAndServe()
+		if errors.Is(err, http.ErrServerClosed) {
+			err = nil
+		}
+		errCh <- err
+	}()
+
+	select {
+	case <-ctx.Done():
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		if err := httpServer.Shutdown(shutdownCtx); err != nil {
+			return err
+		}
+		return <-errCh
+	case err := <-errCh:
+		return err
+	}
+}
+
+func (s *Server) buildHandler() http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /api/v1/health", s.handleHealth)
+	mux.HandleFunc("GET /api/v1/version", s.handleVersion)
+	mux.HandleFunc("GET /api/v1/assets", s.handleAssets)
+	mux.HandleFunc("GET /api/v1/assets/{id}", s.handleAsset)
+	mux.HandleFunc("GET /api/v1/assets/{id}/ancestors", s.handleAncestors)
+	mux.HandleFunc("GET /api/v1/assets/{id}/descendants", s.handleDescendants)
+	mux.HandleFunc("GET /api/v1/assets/{id}/subtree", s.handleSubtree)
+	mux.HandleFunc("GET /api/v1/assets/{id}/connected", s.handleConnected)
+	mux.HandleFunc("GET /api/v1/relations", s.handleRelations)
+	return s.cors(s.auth(mux))
+}
+
+func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
+	writeResponse(w, http.StatusOK, map[string]string{"status": "ok"})
+}
+
+func (s *Server) handleVersion(w http.ResponseWriter, r *http.Request) {
+	writeResponse(w, http.StatusOK, map[string]string{
+		"version":    s.options.Version,
+		"build_time": s.options.BuildTime,
+		"git_commit": s.options.GitCommit,
+	})
+}
+
+func (s *Server) handleAssets(w http.ResponseWriter, r *http.Request) {
+	limit, offset, err := parsePagination(r)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	assets, err := s.store.ListAssets()
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	writeResponse(w, http.StatusOK, paginateAssets(assets, limit, offset))
+}
+
+func (s *Server) handleAsset(w http.ResponseWriter, r *http.Request) {
+	asset, err := s.store.GetAsset(r.PathValue("id"))
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	if asset == nil {
+		writeError(w, http.StatusNotFound, "asset not found")
+		return
+	}
+	writeResponse(w, http.StatusOK, asset)
+}
+
+func (s *Server) handleAncestors(w http.ResponseWriter, r *http.Request) {
+	if !s.requireAssetExists(w, r.PathValue("id")) {
+		return
+	}
+	relTypes, maxDepth, err := parseTraversalQuery(r)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	nodes, err := s.store.GetAncestors(r.PathValue("id"), relTypes, maxDepth)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	writeResponse(w, http.StatusOK, nodes)
+}
+
+func (s *Server) handleDescendants(w http.ResponseWriter, r *http.Request) {
+	if !s.requireAssetExists(w, r.PathValue("id")) {
+		return
+	}
+	relTypes, maxDepth, err := parseTraversalQuery(r)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	nodes, err := s.store.GetDescendants(r.PathValue("id"), relTypes, maxDepth)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	writeResponse(w, http.StatusOK, nodes)
+}
+
+func (s *Server) handleSubtree(w http.ResponseWriter, r *http.Request) {
+	if !s.requireAssetExists(w, r.PathValue("id")) {
+		return
+	}
+	relTypes, maxDepth, err := parseTraversalQuery(r)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	tree, err := s.store.GetSubtree(r.PathValue("id"), relTypes, maxDepth)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	if tree == nil {
+		writeError(w, http.StatusNotFound, "asset not found")
+		return
+	}
+	writeResponse(w, http.StatusOK, tree)
+}
+
+func (s *Server) handleConnected(w http.ResponseWriter, r *http.Request) {
+	if !s.requireAssetExists(w, r.PathValue("id")) {
+		return
+	}
+	relType := core.RelationType(r.URL.Query().Get("relation_type"))
+	if relType != "" && !core.IsValidRelationType(relType) {
+		writeError(w, http.StatusBadRequest, fmt.Sprintf("invalid relation_type: %s", relType))
+		return
+	}
+	nodes, err := s.store.GetConnected(r.PathValue("id"), relType)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	writeResponse(w, http.StatusOK, nodes)
+}
+
+func (s *Server) handleRelations(w http.ResponseWriter, r *http.Request) {
+	relations, err := s.store.ListRelations()
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	source := r.URL.Query().Get("source")
+	target := r.URL.Query().Get("target")
+	relType := core.RelationType(r.URL.Query().Get("type"))
+	if relType != "" && !core.IsValidRelationType(relType) {
+		writeError(w, http.StatusBadRequest, fmt.Sprintf("invalid type: %s", relType))
+		return
+	}
+
+	filtered := make([]*core.AssetRelation, 0, len(relations))
+	for _, relation := range relations {
+		if source != "" && relation.SourceAssetID != source {
+			continue
+		}
+		if target != "" && relation.TargetAssetID != target {
+			continue
+		}
+		if relType != "" && relation.RelationType != relType {
+			continue
+		}
+		filtered = append(filtered, relation)
+	}
+	writeResponse(w, http.StatusOK, filtered)
+}
+
+func (s *Server) requireAssetExists(w http.ResponseWriter, assetID string) bool {
+	exists, err := s.store.AssetExists(assetID)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return false
+	}
+	if !exists {
+		writeError(w, http.StatusNotFound, "asset not found")
+		return false
+	}
+	return true
+}
+
+func (s *Server) auth(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if s.options.Token == "" {
+			next.ServeHTTP(w, r)
+			return
+		}
+		if r.Header.Get("Authorization") != "Bearer "+s.options.Token {
+			writeError(w, http.StatusUnauthorized, "unauthorized")
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+func (s *Server) cors(next http.Handler) http.Handler {
+	allowed := map[string]bool{}
+	allowAll := false
+	for _, origin := range s.options.CORSAllowedOrigins {
+		if origin == "*" {
+			allowAll = true
+			continue
+		}
+		allowed[origin] = true
+	}
+
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		origin := r.Header.Get("Origin")
+		if origin != "" && (allowAll || allowed[origin]) {
+			if allowAll {
+				w.Header().Set("Access-Control-Allow-Origin", "*")
+			} else {
+				w.Header().Set("Access-Control-Allow-Origin", origin)
+				w.Header().Set("Vary", "Origin")
+			}
+			w.Header().Set("Access-Control-Allow-Methods", "GET, OPTIONS")
+			w.Header().Set("Access-Control-Allow-Headers", "Authorization, Content-Type")
+		}
+		if r.Method == http.MethodOptions {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+func parseTraversalQuery(r *http.Request) ([]core.RelationType, int, error) {
+	relTypes, err := parseRelationTypes(r.URL.Query().Get("relation_types"))
+	if err != nil {
+		return nil, 0, err
+	}
+	maxDepth, err := parseOptionalInt(r.URL.Query().Get("max_depth"), 0, "max_depth")
+	if err != nil {
+		return nil, 0, err
+	}
+	return relTypes, maxDepth, nil
+}
+
+func parseRelationTypes(raw string) ([]core.RelationType, error) {
+	if raw == "" {
+		return nil, nil
+	}
+	parts := strings.Split(raw, ",")
+	relTypes := make([]core.RelationType, 0, len(parts))
+	for _, part := range parts {
+		relType := core.RelationType(strings.TrimSpace(part))
+		if relType == "" {
+			continue
+		}
+		if !core.IsValidRelationType(relType) {
+			return nil, fmt.Errorf("invalid relation_type: %s", relType)
+		}
+		relTypes = append(relTypes, relType)
+	}
+	return relTypes, nil
+}
+
+func parsePagination(r *http.Request) (int, int, error) {
+	limit, err := parseOptionalInt(r.URL.Query().Get("limit"), 100, "limit")
+	if err != nil {
+		return 0, 0, err
+	}
+	offset, err := parseOptionalInt(r.URL.Query().Get("offset"), 0, "offset")
+	if err != nil {
+		return 0, 0, err
+	}
+	if limit < 0 {
+		return 0, 0, fmt.Errorf("limit must be >= 0")
+	}
+	if offset < 0 {
+		return 0, 0, fmt.Errorf("offset must be >= 0")
+	}
+	return limit, offset, nil
+}
+
+func parseOptionalInt(raw string, defaultValue int, name string) (int, error) {
+	if raw == "" {
+		return defaultValue, nil
+	}
+	value, err := strconv.Atoi(raw)
+	if err != nil {
+		return 0, fmt.Errorf("%s must be an integer", name)
+	}
+	return value, nil
+}
+
+func paginateAssets(assets []*core.Asset, limit, offset int) []*core.Asset {
+	if offset >= len(assets) {
+		return []*core.Asset{}
+	}
+	end := offset + limit
+	if limit == 0 || end > len(assets) {
+		end = len(assets)
+	}
+	return assets[offset:end]
+}

--- a/internal/httpapi/server_test.go
+++ b/internal/httpapi/server_test.go
@@ -1,0 +1,186 @@
+package httpapi
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/e7217/edg/internal/core"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testResponse struct {
+	Success bool            `json:"success"`
+	Data    json.RawMessage `json:"data,omitempty"`
+	Error   string          `json:"error,omitempty"`
+}
+
+func TestServerHealthAndVersion(t *testing.T) {
+	store := newHTTPTestStore(t)
+	server := httptest.NewServer(NewServer(store, Options{
+		Version:   "test",
+		BuildTime: "now",
+		GitCommit: "abc123",
+	}).Handler())
+	t.Cleanup(server.Close)
+
+	status, resp := getJSON(t, server.URL+"/api/v1/health", "")
+	require.Equal(t, http.StatusOK, status)
+	require.True(t, resp.Success)
+
+	var health map[string]string
+	require.NoError(t, json.Unmarshal(resp.Data, &health))
+	assert.Equal(t, "ok", health["status"])
+
+	status, resp = getJSON(t, server.URL+"/api/v1/version", "")
+	require.Equal(t, http.StatusOK, status)
+	require.True(t, resp.Success)
+
+	var version map[string]string
+	require.NoError(t, json.Unmarshal(resp.Data, &version))
+	assert.Equal(t, "test", version["version"])
+	assert.Equal(t, "abc123", version["git_commit"])
+}
+
+func TestServerAssetsRelationsAndTraversal(t *testing.T) {
+	store := newHTTPTestStore(t)
+	server := httptest.NewServer(NewServer(store, Options{}).Handler())
+	t.Cleanup(server.Close)
+
+	status, resp := getJSON(t, server.URL+"/api/v1/assets?limit=2&offset=0", "")
+	require.Equal(t, http.StatusOK, status)
+	require.True(t, resp.Success)
+
+	var assets []*core.Asset
+	require.NoError(t, json.Unmarshal(resp.Data, &assets))
+	require.Len(t, assets, 2)
+
+	status, resp = getJSON(t, server.URL+"/api/v1/assets/sensor-1", "")
+	require.Equal(t, http.StatusOK, status)
+	require.True(t, resp.Success)
+
+	var asset core.Asset
+	require.NoError(t, json.Unmarshal(resp.Data, &asset))
+	assert.Equal(t, "sensor-1", asset.ID)
+
+	status, resp = getJSON(t, server.URL+"/api/v1/assets/line-1/descendants?relation_types=partOf&max_depth=5", "")
+	require.Equal(t, http.StatusOK, status)
+	require.True(t, resp.Success)
+
+	var descendants []*core.AssetNode
+	require.NoError(t, json.Unmarshal(resp.Data, &descendants))
+	assert.ElementsMatch(t, []string{"equipment-1", "sensor-1"}, assetNodeIDs(descendants))
+
+	status, resp = getJSON(t, server.URL+"/api/v1/relations?source=sensor-1&type=partOf", "")
+	require.Equal(t, http.StatusOK, status)
+	require.True(t, resp.Success)
+
+	var relations []*core.AssetRelation
+	require.NoError(t, json.Unmarshal(resp.Data, &relations))
+	require.Len(t, relations, 1)
+	assert.Equal(t, "equipment-1", relations[0].TargetAssetID)
+}
+
+func TestServerNotFoundAndBadQuery(t *testing.T) {
+	store := newHTTPTestStore(t)
+	server := httptest.NewServer(NewServer(store, Options{}).Handler())
+	t.Cleanup(server.Close)
+
+	status, resp := getJSON(t, server.URL+"/api/v1/assets/missing", "")
+	require.Equal(t, http.StatusNotFound, status)
+	require.False(t, resp.Success)
+	assert.Contains(t, resp.Error, "asset not found")
+
+	status, resp = getJSON(t, server.URL+"/api/v1/assets/line-1/descendants?max_depth=abc", "")
+	require.Equal(t, http.StatusBadRequest, status)
+	require.False(t, resp.Success)
+	assert.Contains(t, resp.Error, "max_depth")
+
+	status, resp = getJSON(t, server.URL+"/api/v1/assets/missing/descendants", "")
+	require.Equal(t, http.StatusNotFound, status)
+	require.False(t, resp.Success)
+	assert.Contains(t, resp.Error, "asset not found")
+}
+
+func TestServerBearerAuth(t *testing.T) {
+	store := newHTTPTestStore(t)
+	server := httptest.NewServer(NewServer(store, Options{Token: "secret"}).Handler())
+	t.Cleanup(server.Close)
+
+	status, resp := getJSON(t, server.URL+"/api/v1/health", "")
+	require.Equal(t, http.StatusUnauthorized, status)
+	require.False(t, resp.Success)
+
+	status, resp = getJSON(t, server.URL+"/api/v1/health", "secret")
+	require.Equal(t, http.StatusOK, status)
+	require.True(t, resp.Success)
+}
+
+func getJSON(t *testing.T, url, token string) (int, testResponse) {
+	t.Helper()
+
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	require.NoError(t, err)
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	res, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer res.Body.Close()
+
+	var resp testResponse
+	require.NoError(t, json.NewDecoder(res.Body).Decode(&resp))
+	return res.StatusCode, resp
+}
+
+func newHTTPTestStore(t *testing.T) *core.Store {
+	t.Helper()
+
+	store, err := core.NewStore(":memory:")
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, store.Close())
+	})
+
+	createHTTPAsset(t, store, "line-1", "Line 1", "line")
+	createHTTPAsset(t, store, "equipment-1", "Equipment 1", "equipment")
+	createHTTPAsset(t, store, "sensor-1", "Sensor 1", "sensor")
+
+	createHTTPRelation(t, store, "rel-equipment-line", "equipment-1", "line-1", core.RelationPartOf)
+	createHTTPRelation(t, store, "rel-sensor-equipment", "sensor-1", "equipment-1", core.RelationPartOf)
+	return store
+}
+
+func createHTTPAsset(t *testing.T, store *core.Store, id, name, templateName string) {
+	t.Helper()
+
+	require.NoError(t, store.CreateAsset(&core.Asset{
+		ID:           id,
+		Name:         name,
+		TemplateName: templateName,
+		CreatedAt:    time.Now(),
+	}))
+}
+
+func createHTTPRelation(t *testing.T, store *core.Store, id, sourceID, targetID string, relationType core.RelationType) {
+	t.Helper()
+
+	require.NoError(t, store.CreateRelation(&core.AssetRelation{
+		ID:            id,
+		SourceAssetID: sourceID,
+		TargetAssetID: targetID,
+		RelationType:  relationType,
+		CreatedAt:     time.Now(),
+	}))
+}
+
+func assetNodeIDs(nodes []*core.AssetNode) []string {
+	ids := make([]string, 0, len(nodes))
+	for _, node := range nodes {
+		ids = append(ids, node.ID)
+	}
+	return ids
+}


### PR DESCRIPTION
## Summary
- add embedded read-only HTTP API for health, version, assets, relations, and traversal
- add optional bearer auth and CORS controls
- wire HTTP config and lifecycle into core startup
- document endpoints and configuration

## Test
- go test ./internal/httpapi -count=1
- go test ./...
- go vet ./...
- go test ./cmd/core ./internal/core ./internal/httpapi -count=1