### PR TITLE
feat(core)!: remove auto-registration, add unknown_asset_policy (Phase 2)

### DIFF
--- a/cmd/core/main.go
+++ b/cmd/core/main.go
@@ -166,11 +166,11 @@ func main() {
 	defer enricher.Stop()
 
 	dataHandler := core.NewDataHandlerWithConfig(js, store, core.DataHandlerOptions{
-		ValidatedSubject:  cfg.JetStream.ValidatedSubject,
-		DeadLetterSubject: cfg.JetStream.DeadLetterSubject,
-		Events:            eventPublisher,
-		RegistrationMode:  cfg.AssetRegistration.Mode,
-		Enricher:          enricher,
+		ValidatedSubject:   cfg.JetStream.ValidatedSubject,
+		DeadLetterSubject:  cfg.JetStream.DeadLetterSubject,
+		Events:             eventPublisher,
+		UnknownAssetPolicy: cfg.UnknownAssetPolicy,
+		Enricher:           enricher,
 	})
 	metaHandler := core.NewMetaHandlerWithOptions(store, loader, core.MetaHandlerOptions{
 		Events:                eventPublisher,

--- a/deploy/configs/core/config.dev.yaml
+++ b/deploy/configs/core/config.dev.yaml
@@ -16,10 +16,10 @@ templates:
   dir: ./templates
   auto_reload: true
 
-asset_registration:
-  # auto creates Asset records for unknown asset_id values.
-  # manual keeps validated data flowing without creating Asset records.
-  mode: auto
+# Behavior for data whose asset_id has no declared master-data record.
+# pass_through: publish un-enriched to validated (default).
+# dead_letter: route to the dead-letter subject instead.
+unknown_asset_policy: pass_through
 
 alarm:
   window_seconds: 5

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -145,19 +145,26 @@ Incoming JSON from adapters:
 
 EDG Core stores asset metadata in SQLite and exposes it through NATS metadata subjects.
 
-### Asset Registration Modes
+### Undeclared Asset Policy
 
-EDG Core controls unknown asset handling with `asset_registration.mode`.
+Master data is created explicitly (metadata API / CLI / UI / import). The data
+plane no longer auto-registers assets. EDG Core controls what happens to data
+whose `asset_id` has no declared Asset record with `unknown_asset_policy`.
 
-| Mode | Behavior |
+| Policy | Behavior |
 | --- | --- |
-| `auto` | Default. Unknown `asset_id` values from data messages create Asset records with `source: "auto"` and publish an asset-created metadata event. |
-| `manual` | Unknown `asset_id` values continue through the validated data subject, but EDG Core does not create Asset records or publish asset-created metadata events. |
+| `pass_through` | Default. The message is published to the validated data subject un-enriched (no ontology metadata is added). No Asset record is created. |
+| `dead_letter` | The message is routed to the dead-letter subject instead of the validated subject. |
+
+Either way, an undeclared-asset counter (`edg_core_undeclared_assets`, expvar) is
+incremented for operator visibility.
 
 ```yaml
-asset_registration:
-  mode: auto
+unknown_asset_policy: pass_through
 ```
+
+> The removed `asset_registration:` block is ignored if still present; EDG Core
+> logs a one-time startup warning pointing to `unknown_asset_policy`.
 
 Asset records include:
 - `id`: stable asset identifier

--- a/internal/core/chaos_test.go
+++ b/internal/core/chaos_test.go
@@ -68,7 +68,7 @@ func TestChaosJetStream_DiscardOldUnderMaxBytesPressure(t *testing.T) {
 	assert.Greater(t, info.State.FirstSeq, uint64(1))
 }
 
-func TestChaosDataHandler_ConcurrentAutoRegistrationSingleAsset(t *testing.T) {
+func TestChaosDataHandler_ConcurrentUndeclaredPassThrough(t *testing.T) {
 	_, _, js := startTestNATSServer(t, true)
 
 	_, err := js.AddStream(&nats.StreamConfig{
@@ -95,13 +95,15 @@ func TestChaosDataHandler_ConcurrentAutoRegistrationSingleAsset(t *testing.T) {
 	}
 	wg.Wait()
 
+	// pass_through (default): undeclared assets are never auto-registered,
+	// even under concurrency, and all messages still pass through.
 	asset, err := store.GetAsset("shared-asset")
 	require.NoError(t, err)
-	require.NotNil(t, asset)
+	require.Nil(t, asset)
 
 	assets, err := store.ListAssets()
 	require.NoError(t, err)
-	assert.Len(t, assets, 1)
+	assert.Len(t, assets, 0)
 	assert.Equal(t, 100, handler.GetDataCount())
 }
 

--- a/internal/core/config.go
+++ b/internal/core/config.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"fmt"
+	"log"
 	"os"
 	"time"
 
@@ -15,22 +16,22 @@ const (
 )
 
 const (
-	RegistrationModeAuto   = "auto"
-	RegistrationModeManual = "manual"
+	UnknownAssetPolicyPassThrough = "pass_through"
+	UnknownAssetPolicyDeadLetter  = "dead_letter"
 )
 
 // CoreConfig contains runtime settings for the embedded core process.
 type CoreConfig struct {
-	NATS              NATSConfig              `yaml:"nats"`
-	Storage           StorageConfig           `yaml:"storage"`
-	Templates         TemplateConfig          `yaml:"templates"`
-	Logging           LoggingConfig           `yaml:"logging"`
-	JetStream         JetStreamConfig         `yaml:"jetstream"`
-	AssetRegistration AssetRegistrationConfig `yaml:"asset_registration"`
-	Alarm             AlarmConfig             `yaml:"alarm"`
-	Constraints       ConstraintsConfig       `yaml:"constraints"`
-	HTTP              HTTPConfig              `yaml:"http"`
-	Sink              SinkConfig              `yaml:"sink"`
+	NATS               NATSConfig        `yaml:"nats"`
+	Storage            StorageConfig     `yaml:"storage"`
+	Templates          TemplateConfig    `yaml:"templates"`
+	Logging            LoggingConfig     `yaml:"logging"`
+	JetStream          JetStreamConfig   `yaml:"jetstream"`
+	UnknownAssetPolicy string            `yaml:"unknown_asset_policy"`
+	Alarm              AlarmConfig       `yaml:"alarm"`
+	Constraints        ConstraintsConfig `yaml:"constraints"`
+	HTTP               HTTPConfig        `yaml:"http"`
+	Sink               SinkConfig        `yaml:"sink"`
 }
 
 type NATSConfig struct {
@@ -61,10 +62,6 @@ type JetStreamConfig struct {
 	Stream            JetStreamStreamConfig `yaml:"stream"`
 	ValidatedSubject  string                `yaml:"validated_subject"`
 	DeadLetterSubject string                `yaml:"dead_letter_subject"`
-}
-
-type AssetRegistrationConfig struct {
-	Mode string `yaml:"mode"`
 }
 
 type AlarmConfig struct {
@@ -144,9 +141,7 @@ func DefaultCoreConfig() CoreConfig {
 				Discard:   "old",
 			},
 		},
-		AssetRegistration: AssetRegistrationConfig{
-			Mode: RegistrationModeAuto,
-		},
+		UnknownAssetPolicy: UnknownAssetPolicyPassThrough,
 		Alarm: AlarmConfig{
 			WindowSeconds:     int(DefaultAlarmWindow / time.Second),
 			MaxTraversalDepth: DefaultTraversalMaxDepth,
@@ -184,11 +179,24 @@ func LoadCoreConfig(path string) (CoreConfig, error) {
 	if err := yaml.Unmarshal(data, &cfg); err != nil {
 		return cfg, fmt.Errorf("failed to parse core config: %w", err)
 	}
+	warnLegacyConfigKeys(data)
 	cfg.applyDefaults()
 	if err := cfg.validate(); err != nil {
 		return cfg, err
 	}
 	return cfg, nil
+}
+
+// warnLegacyConfigKeys logs a one-time warning when removed config keys are still
+// present in a user's YAML (yaml.Unmarshal silently ignores unknown keys).
+func warnLegacyConfigKeys(data []byte) {
+	var raw map[string]any
+	if err := yaml.Unmarshal(data, &raw); err != nil {
+		return
+	}
+	if _, ok := raw["asset_registration"]; ok {
+		log.Printf("[Config] 'asset_registration' is removed; use 'unknown_asset_policy' (pass_through|dead_letter)")
+	}
 }
 
 func (c *CoreConfig) applyDefaults() {
@@ -221,8 +229,8 @@ func (c *CoreConfig) applyDefaults() {
 	if c.JetStream.DeadLetterSubject == "" {
 		c.JetStream.DeadLetterSubject = defaults.JetStream.DeadLetterSubject
 	}
-	if c.AssetRegistration.Mode == "" {
-		c.AssetRegistration.Mode = defaults.AssetRegistration.Mode
+	if c.UnknownAssetPolicy == "" {
+		c.UnknownAssetPolicy = defaults.UnknownAssetPolicy
 	}
 	if c.Alarm.WindowSeconds == 0 {
 		c.Alarm.WindowSeconds = defaults.Alarm.WindowSeconds
@@ -265,10 +273,10 @@ func (c *SinkConfig) applyDefaults(defaults SinkConfig) {
 }
 
 func (c CoreConfig) validate() error {
-	switch c.AssetRegistration.Mode {
-	case RegistrationModeAuto, RegistrationModeManual:
+	switch c.UnknownAssetPolicy {
+	case UnknownAssetPolicyPassThrough, UnknownAssetPolicyDeadLetter:
 	default:
-		return fmt.Errorf("invalid asset_registration.mode: %q (allowed: auto, manual)", c.AssetRegistration.Mode)
+		return fmt.Errorf("invalid unknown_asset_policy: %q (allowed: pass_through, dead_letter)", c.UnknownAssetPolicy)
 	}
 	if c.Alarm.WindowSeconds <= 0 {
 		return fmt.Errorf("invalid alarm.window_seconds: %d (must be > 0)", c.Alarm.WindowSeconds)

--- a/internal/core/config_test.go
+++ b/internal/core/config_test.go
@@ -26,10 +26,10 @@ func TestDefaultCoreConfig_JetStreamPolicy(t *testing.T) {
 	assert.True(t, cfg.Storage.AutoMigrate)
 }
 
-func TestDefaultCoreConfig_AssetRegistrationMode(t *testing.T) {
+func TestDefaultCoreConfig_UnknownAssetPolicy(t *testing.T) {
 	cfg := DefaultCoreConfig()
 
-	assert.Equal(t, RegistrationModeAuto, cfg.AssetRegistration.Mode)
+	assert.Equal(t, UnknownAssetPolicyPassThrough, cfg.UnknownAssetPolicy)
 }
 
 func TestDefaultCoreConfig_Alarm(t *testing.T) {
@@ -170,7 +170,20 @@ jetstream:
 	assert.Equal(t, nats.LimitsPolicy, streamConfig.Retention)
 }
 
-func TestLoadCoreConfig_AssetRegistrationModeFromYAML(t *testing.T) {
+func TestLoadCoreConfig_UnknownAssetPolicyFromYAML(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	err := os.WriteFile(path, []byte(`
+unknown_asset_policy: dead_letter
+`), 0644)
+	require.NoError(t, err)
+
+	cfg, err := LoadCoreConfig(path)
+	require.NoError(t, err)
+
+	assert.Equal(t, UnknownAssetPolicyDeadLetter, cfg.UnknownAssetPolicy)
+}
+
+func TestLoadCoreConfig_LegacyAssetRegistrationIgnored(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "config.yaml")
 	err := os.WriteFile(path, []byte(`
 asset_registration:
@@ -181,7 +194,8 @@ asset_registration:
 	cfg, err := LoadCoreConfig(path)
 	require.NoError(t, err)
 
-	assert.Equal(t, RegistrationModeManual, cfg.AssetRegistration.Mode)
+	// Legacy key is ignored; policy falls back to the default.
+	assert.Equal(t, UnknownAssetPolicyPassThrough, cfg.UnknownAssetPolicy)
 }
 
 func TestLoadCoreConfig_AlarmFromYAML(t *testing.T) {
@@ -235,18 +249,17 @@ http:
 	assert.Equal(t, []string{"http://localhost:3000"}, cfg.HTTP.CORSAllowedOrigins)
 }
 
-func TestLoadCoreConfig_RejectsInvalidAssetRegistrationMode(t *testing.T) {
+func TestLoadCoreConfig_RejectsInvalidUnknownAssetPolicy(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "config.yaml")
 	err := os.WriteFile(path, []byte(`
-asset_registration:
-  mode: disabled
+unknown_asset_policy: bogus
 `), 0644)
 	require.NoError(t, err)
 
 	_, err = LoadCoreConfig(path)
 
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), `invalid asset_registration.mode: "disabled"`)
+	assert.Contains(t, err.Error(), `invalid unknown_asset_policy: "bogus"`)
 }
 
 func TestLoadCoreConfig_RejectsInvalidAlarmConfig(t *testing.T) {

--- a/internal/core/handler.go
+++ b/internal/core/handler.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"encoding/json"
+	"errors"
 	"expvar"
 	"log"
 	"sync"
@@ -12,29 +13,34 @@ import (
 
 // DataHandler handles NATS messages for asset data
 type DataHandler struct {
-	mu                sync.Mutex
-	data              []AssetData           // in-memory storage (PoC)
-	store             *Store                // for auto-registration
-	js                nats.JetStreamContext // for publishing to JetStream
-	validatedSubject  string
-	deadLetterSubject string
-	registrationMode  string
-	events            *EventPublisher // for metadata change notifications
-	enricher          *Enricher
+	mu                 sync.Mutex
+	data               []AssetData           // in-memory storage (PoC)
+	store              *Store                // for undeclared-asset detection
+	js                 nats.JetStreamContext // for publishing to JetStream
+	validatedSubject   string
+	deadLetterSubject  string
+	unknownAssetPolicy string
+	events             *EventPublisher // for metadata change notifications
+	enricher           *Enricher
 }
 
 var (
 	jetStreamPublishFailures = expvar.NewInt("edg_core_jetstream_publish_failures")
 	jetStreamDeadLetters     = expvar.NewInt("edg_core_jetstream_dead_letters")
 	jetStreamDeadLetterFails = expvar.NewInt("edg_core_jetstream_dead_letter_failures")
+	undeclaredAssets         = expvar.NewInt("edg_core_undeclared_assets")
 )
 
+// errUndeclaredAsset is the dead-letter reason when an undeclared asset_id is
+// routed under unknown_asset_policy = dead_letter.
+var errUndeclaredAsset = errors.New("undeclared asset")
+
 type DataHandlerOptions struct {
-	ValidatedSubject  string
-	DeadLetterSubject string
-	Events            *EventPublisher
-	RegistrationMode  string
-	Enricher          *Enricher
+	ValidatedSubject   string
+	DeadLetterSubject  string
+	Events             *EventPublisher
+	UnknownAssetPolicy string
+	Enricher           *Enricher
 }
 
 // DeadLetterMessage records a failed core-to-JetStream publish attempt.
@@ -65,20 +71,20 @@ func NewDataHandlerWithConfig(js nats.JetStreamContext, store *Store, opts DataH
 	if deadLetterSubject == "" {
 		deadLetterSubject = DefaultDeadLetterSubject
 	}
-	registrationMode := opts.RegistrationMode
-	if registrationMode == "" {
-		registrationMode = RegistrationModeAuto
+	unknownAssetPolicy := opts.UnknownAssetPolicy
+	if unknownAssetPolicy == "" {
+		unknownAssetPolicy = UnknownAssetPolicyPassThrough
 	}
 
 	return &DataHandler{
-		data:              make([]AssetData, 0),
-		store:             store,
-		js:                js,
-		validatedSubject:  validatedSubject,
-		deadLetterSubject: deadLetterSubject,
-		registrationMode:  registrationMode,
-		events:            opts.Events,
-		enricher:          opts.Enricher,
+		data:               make([]AssetData, 0),
+		store:              store,
+		js:                 js,
+		validatedSubject:   validatedSubject,
+		deadLetterSubject:  deadLetterSubject,
+		unknownAssetPolicy: unknownAssetPolicy,
+		events:             opts.Events,
+		enricher:           opts.Enricher,
 	}
 }
 
@@ -102,31 +108,17 @@ func (h *DataHandler) HandleAssetData(msg *nats.Msg) {
 		return
 	}
 
-	// Register metadata for unknown assets only when automatic registration is enabled.
+	// Undeclared assets follow the configured unknown_asset_policy. Master data is
+	// created explicitly (API/CLI/UI/import); the data plane no longer auto-registers.
 	if h.store != nil {
 		if exists, _ := h.store.AssetExists(data.AssetID); !exists {
-			switch h.registrationMode {
-			case RegistrationModeAuto:
-				now := time.Now()
-				asset := &Asset{
-					ID:        data.AssetID,
-					Name:      data.AssetID,
-					Source:    SourceAuto,
-					CreatedAt: now,
-					UpdatedAt: now,
-				}
-				if err := h.store.CreateAsset(asset); err == nil {
-					h.events.PublishAssetChanged(MetaChangeEvent{
-						EventType: EventCreated,
-						EntityID:  asset.ID,
-						Source:    SourceAuto,
-						After:     asset,
-					})
-					log.Printf("[Core] Auto-registered asset: %s", data.AssetID)
-				}
-			case RegistrationModeManual:
-				log.Printf("[Core] unregistered asset (manual mode): %s", data.AssetID)
+			undeclaredAssets.Add(1)
+			if h.unknownAssetPolicy == UnknownAssetPolicyDeadLetter {
+				log.Printf("[Core] undeclared asset -> dead-letter: %s", data.AssetID)
+				h.publishDeadLetter(msg, errUndeclaredAsset)
+				return
 			}
+			log.Printf("[Core] undeclared asset (pass_through): %s", data.AssetID)
 		}
 	}
 
@@ -169,7 +161,7 @@ func (h *DataHandler) HandleAssetData(msg *nats.Msg) {
 }
 
 func (h *DataHandler) publishDeadLetter(msg *nats.Msg, publishErr error) {
-	if h.deadLetterSubject == "" {
+	if h.deadLetterSubject == "" || h.js == nil {
 		return
 	}
 

--- a/internal/core/handler_jetstream_test.go
+++ b/internal/core/handler_jetstream_test.go
@@ -102,7 +102,8 @@ func TestHandleAssetData_WithJetStream(t *testing.T) {
 	assert.Equal(t, 1, handler.GetDataCount())
 }
 
-// TestHandleAssetData_WithJetStreamAndStore tests both JetStream and auto-registration
+// TestHandleAssetData_WithJetStreamAndStore tests JetStream publish with pass_through
+// for an undeclared asset (no auto-registration).
 func TestHandleAssetData_WithJetStreamAndStore(t *testing.T) {
 	_, _, js := startTestNATSServer(t, true)
 
@@ -140,13 +141,12 @@ func TestHandleAssetData_WithJetStreamAndStore(t *testing.T) {
 	// Process message
 	handler.HandleAssetData(msg)
 
-	// Verify asset was auto-registered
+	// pass_through (default): the undeclared asset is NOT registered.
 	asset, err := store.GetAsset("new-sensor")
 	require.NoError(t, err)
-	require.NotNil(t, asset)
-	assert.Equal(t, "new-sensor", asset.ID)
+	assert.Nil(t, asset)
 
-	// Verify data was stored
+	// Verify data was still stored (passed through to validated).
 	assert.Equal(t, 1, handler.GetDataCount())
 }
 
@@ -208,11 +208,11 @@ func TestHandleAssetData_WithEnricherPublishesMetadata(t *testing.T) {
 	handler.mu.Unlock()
 }
 
-func TestHandleAssetData_ManualModePublishesValidatedData(t *testing.T) {
+func TestHandleAssetData_PassThroughPublishesValidatedData(t *testing.T) {
 	_, nc, js := startTestNATSServer(t, true)
 
 	_, err := js.AddStream(&nats.StreamConfig{
-		Name:     "MANUAL_MODE_STREAM",
+		Name:     "PASSTHROUGH_STREAM",
 		Subjects: []string{"platform.data.>"},
 		Storage:  nats.MemoryStorage,
 	})
@@ -222,9 +222,8 @@ func TestHandleAssetData_ManualModePublishesValidatedData(t *testing.T) {
 	require.NoError(t, err)
 	defer store.Close()
 
-	handler := NewDataHandlerWithConfig(js, store, DataHandlerOptions{
-		RegistrationMode: RegistrationModeManual,
-	})
+	// pass_through is the default policy.
+	handler := NewDataHandler(js, store)
 
 	tempValue := 25.5
 	data := &AssetData{

--- a/internal/core/handler_test.go
+++ b/internal/core/handler_test.go
@@ -56,56 +56,19 @@ func TestHandleAssetData_InvalidJSON(t *testing.T) {
 	assert.Equal(t, 0, handler.GetDataCount())
 }
 
-// TestHandleAssetData_AutoRegister tests auto-registration of unknown assets
-func TestHandleAssetData_AutoRegister(t *testing.T) {
+// TestHandleAssetData_PassThrough_DoesNotRegister verifies the default policy:
+// an undeclared asset_id is not registered, but its data still passes through.
+func TestHandleAssetData_PassThrough_DoesNotRegister(t *testing.T) {
 	store, err := NewStore(":memory:")
 	require.NoError(t, err)
 	defer store.Close()
 
 	handler := NewDataHandler(nil, store)
 
+	before := undeclaredAssets.Value()
 	tempValue := 25.5
 	data := &AssetData{
-		AssetID:   "new-sensor",
-		Timestamp: 1234567890,
-		Values: []TagValue{
-			{Name: "temperature", Number: &tempValue},
-		},
-	}
-
-	jsonData, err := json.Marshal(data)
-	require.NoError(t, err)
-
-	msg := &nats.Msg{
-		Subject: "platform.data.raw",
-		Data:    jsonData,
-	}
-
-	// Process message
-	handler.HandleAssetData(msg)
-
-	// Verify asset was auto-registered
-	asset, err := store.GetAsset("new-sensor")
-	require.NoError(t, err)
-	require.NotNil(t, asset)
-	assert.Equal(t, "new-sensor", asset.ID)
-	assert.Equal(t, "new-sensor", asset.Name)
-	assert.Equal(t, SourceAuto, asset.Source)
-	assert.False(t, asset.UpdatedAt.IsZero())
-}
-
-func TestHandleAssetData_ManualMode_DoesNotRegister(t *testing.T) {
-	store, err := NewStore(":memory:")
-	require.NoError(t, err)
-	defer store.Close()
-
-	handler := NewDataHandlerWithConfig(nil, store, DataHandlerOptions{
-		RegistrationMode: RegistrationModeManual,
-	})
-
-	tempValue := 25.5
-	data := &AssetData{
-		AssetID:   "manual-sensor",
+		AssetID:   "undeclared-sensor",
 		Timestamp: 1234567890,
 		Values: []TagValue{
 			{Name: "temperature", Number: &tempValue},
@@ -116,14 +79,48 @@ func TestHandleAssetData_ManualMode_DoesNotRegister(t *testing.T) {
 	require.NoError(t, err)
 
 	handler.HandleAssetData(&nats.Msg{
-		Subject: "platform.data.raw",
+		Subject: "platform.data.asset",
 		Data:    jsonData,
 	})
 
-	asset, err := store.GetAsset("manual-sensor")
+	asset, err := store.GetAsset("undeclared-sensor")
 	require.NoError(t, err)
 	assert.Nil(t, asset)
 	assert.Equal(t, 1, handler.GetDataCount())
+	assert.Equal(t, before+1, undeclaredAssets.Value())
+}
+
+// TestHandleAssetData_DeadLetterPolicy_SkipsValidated verifies the dead_letter
+// policy: an undeclared asset_id returns early (not stored / not validated).
+func TestHandleAssetData_DeadLetterPolicy_SkipsValidated(t *testing.T) {
+	store, err := NewStore(":memory:")
+	require.NoError(t, err)
+	defer store.Close()
+
+	handler := NewDataHandlerWithConfig(nil, store, DataHandlerOptions{
+		UnknownAssetPolicy: UnknownAssetPolicyDeadLetter,
+	})
+
+	before := undeclaredAssets.Value()
+	tempValue := 25.5
+	data := &AssetData{
+		AssetID: "undeclared-dl-sensor",
+		Values:  []TagValue{{Name: "temperature", Number: &tempValue}},
+	}
+
+	jsonData, err := json.Marshal(data)
+	require.NoError(t, err)
+
+	handler.HandleAssetData(&nats.Msg{
+		Subject: "platform.data.asset",
+		Data:    jsonData,
+	})
+
+	assert.Equal(t, 0, handler.GetDataCount())
+	assert.Equal(t, before+1, undeclaredAssets.Value())
+	asset, err := store.GetAsset("undeclared-dl-sensor")
+	require.NoError(t, err)
+	assert.Nil(t, asset)
 }
 
 func TestNewDataHandlerWithSubjects(t *testing.T) {
@@ -141,22 +138,22 @@ func TestNewDataHandlerWithSubjects(t *testing.T) {
 func TestNewDataHandlerWithConfig(t *testing.T) {
 	publisher := NewEventPublisher(nil)
 	handler := NewDataHandlerWithConfig(nil, nil, DataHandlerOptions{
-		ValidatedSubject:  "custom.validated",
-		DeadLetterSubject: "custom.deadletter",
-		Events:            publisher,
-		RegistrationMode:  RegistrationModeManual,
+		ValidatedSubject:   "custom.validated",
+		DeadLetterSubject:  "custom.deadletter",
+		Events:             publisher,
+		UnknownAssetPolicy: UnknownAssetPolicyDeadLetter,
 	})
 
 	require.NotNil(t, handler)
 	assert.Equal(t, "custom.validated", handler.validatedSubject)
 	assert.Equal(t, "custom.deadletter", handler.deadLetterSubject)
-	assert.Equal(t, RegistrationModeManual, handler.registrationMode)
+	assert.Equal(t, UnknownAssetPolicyDeadLetter, handler.unknownAssetPolicy)
 	assert.Same(t, publisher, handler.events)
 
 	defaults := NewDataHandlerWithConfig(nil, nil, DataHandlerOptions{})
 	assert.Equal(t, DefaultValidatedDataSubject, defaults.validatedSubject)
 	assert.Equal(t, DefaultDeadLetterSubject, defaults.deadLetterSubject)
-	assert.Equal(t, RegistrationModeAuto, defaults.registrationMode)
+	assert.Equal(t, UnknownAssetPolicyPassThrough, defaults.unknownAssetPolicy)
 }
 
 func TestNewDataHandlerWithSubjectsAndEvents(t *testing.T) {
@@ -169,8 +166,7 @@ func TestNewDataHandlerWithSubjectsAndEvents(t *testing.T) {
 	assert.Same(t, publisher, handler.events)
 }
 
-// TestHandleAssetData_AutoRegisterPublishesChangedEvent tests auto-registration events.
-func TestHandleAssetData_AutoRegisterPublishesChangedEvent(t *testing.T) {
+func TestHandleAssetData_PassThrough_NoChangeEvent(t *testing.T) {
 	_, nc, _ := startTestNATSServer(t, false)
 
 	store, err := NewStore(":memory:")
@@ -179,50 +175,6 @@ func TestHandleAssetData_AutoRegisterPublishesChangedEvent(t *testing.T) {
 
 	assetEvents := subscribeMetaEvents(t, nc, SubjectAssetChanged)
 	handler := NewDataHandler(nil, store, NewEventPublisher(nc))
-
-	tempValue := 25.5
-	data := &AssetData{
-		AssetID:   "auto-sensor",
-		Timestamp: time.Now().Unix(),
-		Values: []TagValue{
-			{Name: "temperature", Number: &tempValue},
-		},
-	}
-
-	jsonData, err := json.Marshal(data)
-	require.NoError(t, err)
-
-	handler.HandleAssetData(&nats.Msg{
-		Subject: "platform.data.raw",
-		Data:    jsonData,
-	})
-
-	ev := requireMetaEvent(t, assetEvents)
-	assert.Equal(t, EventCreated, ev.EventType)
-	assert.Equal(t, EntityAsset, ev.EntityType)
-	assert.Equal(t, "auto-sensor", ev.EntityID)
-	assert.Equal(t, SourceAuto, ev.Source)
-	assert.Empty(t, ev.Before)
-	require.NotEmpty(t, ev.After)
-
-	var after Asset
-	require.NoError(t, json.Unmarshal(ev.After, &after))
-	assert.Equal(t, "auto-sensor", after.ID)
-	assert.Equal(t, SourceAuto, after.Source)
-}
-
-func TestHandleAssetData_ManualMode_NoChangeEvent(t *testing.T) {
-	_, nc, _ := startTestNATSServer(t, false)
-
-	store, err := NewStore(":memory:")
-	require.NoError(t, err)
-	defer store.Close()
-
-	assetEvents := subscribeMetaEvents(t, nc, SubjectAssetChanged)
-	handler := NewDataHandlerWithConfig(nil, store, DataHandlerOptions{
-		Events:           NewEventPublisher(nc),
-		RegistrationMode: RegistrationModeManual,
-	})
 
 	tempValue := 25.5
 	data := &AssetData{
@@ -274,7 +226,7 @@ func TestHandleAssetData_ExistingAssetDoesNotPublishChangedEvent(t *testing.T) {
 	requireNoMetaEvent(t, assetEvents)
 }
 
-func TestHandleAssetData_ManualMode_ExistingAssetUnaffected(t *testing.T) {
+func TestHandleAssetData_ExistingAssetUnaffected(t *testing.T) {
 	store, err := NewStore(":memory:")
 	require.NoError(t, err)
 	defer store.Close()
@@ -288,9 +240,7 @@ func TestHandleAssetData_ManualMode_ExistingAssetUnaffected(t *testing.T) {
 		UpdatedAt: createdAt,
 	}))
 
-	handler := NewDataHandlerWithConfig(nil, store, DataHandlerOptions{
-		RegistrationMode: RegistrationModeManual,
-	})
+	handler := NewDataHandler(nil, store)
 
 	tempValue := 25.5
 	data := &AssetData{


### PR DESCRIPTION
## Summary

**Phase 2** of the [unified master-data control design](https://github.com/e7217/edg/blob/main/docs/superpowers/specs/2026-06-18-unified-master-data-control-design.md): remove auto-registration so master data is created **only** explicitly (metadata API / CLI / UI / import), and make undeclared-asset handling an explicit policy.

## What changed

- **Removed** the data-plane auto-registration branch in `HandleAssetData` and the entire `RegistrationMode` surface (config struct/consts/validate, `DataHandler` field/option, `main.go` wiring).
- **Added** `unknown_asset_policy` config (replaces `asset_registration`):
  - `pass_through` (default) — publish un-enriched to the validated subject (same as the old `manual` mode; no data loss).
  - `dead_letter` — route undeclared-asset data to the dead-letter subject (reuses `publishDeadLetter`).
- **Added** expvar counter `edg_core_undeclared_assets` for visibility.
- **Added** a one-time startup warning when a legacy `asset_registration` key is still present (otherwise ignored).
- Updated `docs/USER_GUIDE.md` and `deploy/configs/core/config.dev.yaml`.

## Behavior / tests

- `pass_through` preserves the prior manual-mode behavior, so the data path is unchanged for undeclared assets by default.
- Updated/added tests: config (default/from-YAML/reject/legacy-key), handler (pass_through, dead_letter early-return + counter), JetStream pass-through publish, and the chaos concurrency test (now asserts no auto-registration under load).

## Verification

```
go build ./...   # ok
go vet ./...      # clean
go test ./...     # cmd/core, contexts, internal/core, internal/httpapi all ok
```

## ⚠️ Breaking change

`asset_registration.mode` (auto|manual) is removed; use `unknown_asset_policy` (pass_through|dead_letter). Existing `asset_registration` config is ignored with a warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HUdtJkgqoi5UmN3fAifmAu