### PR TITLE
feat(httpapi): add master-data write endpoints + auth hardening (Phase 3)

### DIFF
--- a/cmd/core/main.go
+++ b/cmd/core/main.go
@@ -176,6 +176,7 @@ func main() {
 		Events:                eventPublisher,
 		ConstraintEnforcement: cfg.Constraints.Enforcement,
 	})
+	metaService := core.NewMetadataService(store, loader, eventPublisher, cfg.Constraints.Enforcement)
 	alarmHandler := core.NewAlarmHandler(store, eventPublisher, core.AlarmHandlerOptions{
 		Window:            time.Duration(cfg.Alarm.WindowSeconds) * time.Second,
 		MaxTraversalDepth: cfg.Alarm.MaxTraversalDepth,
@@ -198,7 +199,7 @@ func main() {
 	}
 
 	if cfg.HTTP.Enabled {
-		httpServer := httpapi.NewServer(store, httpapi.Options{
+		httpServer := httpapi.NewServer(store, metaService, httpapi.Options{
 			Address:            cfg.HTTP.Address,
 			TokenEnv:           cfg.HTTP.TokenEnv,
 			CORSAllowedOrigins: cfg.HTTP.CORSAllowedOrigins,

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -344,8 +344,9 @@ outside this PoC scope.
 
 ## HTTP Metadata API
 
-EDG Core can expose a read-only HTTP API for browser dashboards and operator
-tools. It is disabled by default outside the development config.
+EDG Core can expose an HTTP API for browser dashboards and operator tools. Reads
+are available anonymously when no token is configured; **writes always require a
+non-empty bearer token**. It is disabled by default outside the development config.
 
 ```yaml
 http:
@@ -379,6 +380,16 @@ Available endpoints:
 | `GET` | `/api/v1/assets/{id}/subtree?relation_types=partOf&max_depth=10` | Recursive tree. |
 | `GET` | `/api/v1/assets/{id}/connected?relation_type=connectedTo` | One-hop relation query. |
 | `GET` | `/api/v1/relations?source=&target=&type=` | List and filter relations. |
+| `POST` | `/api/v1/assets` | Create an asset. **(write — token required)** |
+| `PUT` | `/api/v1/assets/{id}` | Replace an asset's metadata. **(write)** |
+| `DELETE` | `/api/v1/assets/{id}?source=` | Delete an asset. **(write)** |
+| `POST` | `/api/v1/relations` | Create a relation. **(write)** |
+| `DELETE` | `/api/v1/relations/{id}?source=` | Delete a relation. **(write)** |
+
+Write requests share the same validation, constraint enforcement, and change
+events as the NATS metadata API (both go through the core `MetadataService`).
+Errors map to HTTP status codes: `400` validation, `404` not found, `409`
+conflict (duplicate name), `422` constraint violation.
 
 Example:
 

--- a/internal/httpapi/server.go
+++ b/internal/httpapi/server.go
@@ -30,11 +30,12 @@ type Options struct {
 
 type Server struct {
 	store   *core.Store
+	service *core.MetadataService
 	options Options
 	handler http.Handler
 }
 
-func NewServer(store *core.Store, opts Options) *Server {
+func NewServer(store *core.Store, service *core.MetadataService, opts Options) *Server {
 	if opts.Address == "" {
 		opts.Address = defaultAddress
 	}
@@ -46,6 +47,7 @@ func NewServer(store *core.Store, opts Options) *Server {
 	}
 	server := &Server{
 		store:   store,
+		service: service,
 		options: opts,
 	}
 	server.handler = server.buildHandler()
@@ -96,6 +98,14 @@ func (s *Server) buildHandler() http.Handler {
 	mux.HandleFunc("GET /api/v1/assets/{id}/subtree", s.handleSubtree)
 	mux.HandleFunc("GET /api/v1/assets/{id}/connected", s.handleConnected)
 	mux.HandleFunc("GET /api/v1/relations", s.handleRelations)
+
+	// Write endpoints (Phase 3). All mutations go through MetadataService so
+	// validation, constraint enforcement, and change events match the NATS path.
+	mux.HandleFunc("POST /api/v1/assets", s.handleAssetCreate)
+	mux.HandleFunc("PUT /api/v1/assets/{id}", s.handleAssetUpdate)
+	mux.HandleFunc("DELETE /api/v1/assets/{id}", s.handleAssetDelete)
+	mux.HandleFunc("POST /api/v1/relations", s.handleRelationCreate)
+	mux.HandleFunc("DELETE /api/v1/relations/{id}", s.handleRelationDelete)
 	return s.cors(s.auth(mux))
 }
 
@@ -254,9 +264,24 @@ func (s *Server) requireAssetExists(w http.ResponseWriter, assetID string) bool 
 	return true
 }
 
+func isWriteMethod(method string) bool {
+	switch method {
+	case http.MethodPost, http.MethodPut, http.MethodDelete, http.MethodPatch:
+		return true
+	default:
+		return false
+	}
+}
+
 func (s *Server) auth(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if s.options.Token == "" {
+			// Reads stay open when no token is configured, but writes are never
+			// anonymous: they require a non-empty bearer token.
+			if isWriteMethod(r.Method) {
+				writeError(w, http.StatusUnauthorized, "write access requires a configured bearer token")
+				return
+			}
 			next.ServeHTTP(w, r)
 			return
 		}
@@ -288,7 +313,7 @@ func (s *Server) cors(next http.Handler) http.Handler {
 				w.Header().Set("Access-Control-Allow-Origin", origin)
 				w.Header().Set("Vary", "Origin")
 			}
-			w.Header().Set("Access-Control-Allow-Methods", "GET, OPTIONS")
+			w.Header().Set("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS")
 			w.Header().Set("Access-Control-Allow-Headers", "Authorization, Content-Type")
 		}
 		if r.Method == http.MethodOptions {

--- a/internal/httpapi/server_test.go
+++ b/internal/httpapi/server_test.go
@@ -20,7 +20,7 @@ type testResponse struct {
 
 func TestServerHealthAndVersion(t *testing.T) {
 	store := newHTTPTestStore(t)
-	server := httptest.NewServer(NewServer(store, Options{
+	server := httptest.NewServer(newHTTPTestServer(store, Options{
 		Version:   "test",
 		BuildTime: "now",
 		GitCommit: "abc123",
@@ -47,7 +47,7 @@ func TestServerHealthAndVersion(t *testing.T) {
 
 func TestServerAssetsRelationsAndTraversal(t *testing.T) {
 	store := newHTTPTestStore(t)
-	server := httptest.NewServer(NewServer(store, Options{}).Handler())
+	server := httptest.NewServer(newHTTPTestServer(store, Options{}).Handler())
 	t.Cleanup(server.Close)
 
 	status, resp := getJSON(t, server.URL+"/api/v1/assets?limit=2&offset=0", "")
@@ -86,7 +86,7 @@ func TestServerAssetsRelationsAndTraversal(t *testing.T) {
 
 func TestServerNotFoundAndBadQuery(t *testing.T) {
 	store := newHTTPTestStore(t)
-	server := httptest.NewServer(NewServer(store, Options{}).Handler())
+	server := httptest.NewServer(newHTTPTestServer(store, Options{}).Handler())
 	t.Cleanup(server.Close)
 
 	status, resp := getJSON(t, server.URL+"/api/v1/assets/missing", "")
@@ -107,7 +107,7 @@ func TestServerNotFoundAndBadQuery(t *testing.T) {
 
 func TestServerBearerAuth(t *testing.T) {
 	store := newHTTPTestStore(t)
-	server := httptest.NewServer(NewServer(store, Options{Token: "secret"}).Handler())
+	server := httptest.NewServer(newHTTPTestServer(store, Options{Token: "secret"}).Handler())
 	t.Cleanup(server.Close)
 
 	status, resp := getJSON(t, server.URL+"/api/v1/health", "")

--- a/internal/httpapi/write.go
+++ b/internal/httpapi/write.go
@@ -1,0 +1,97 @@
+package httpapi
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/e7217/edg/internal/core"
+)
+
+// httpStatusForError maps a MetadataService error to an HTTP status code using
+// its typed ErrorKind. Unknown errors map to 500.
+func httpStatusForError(err error) int {
+	switch core.KindOf(err) {
+	case core.ErrValidation:
+		return http.StatusBadRequest
+	case core.ErrNotFound:
+		return http.StatusNotFound
+	case core.ErrConflict:
+		return http.StatusConflict
+	case core.ErrConstraint:
+		return http.StatusUnprocessableEntity
+	default:
+		return http.StatusInternalServerError
+	}
+}
+
+func decodeJSON(w http.ResponseWriter, r *http.Request, dst any) bool {
+	if err := json.NewDecoder(r.Body).Decode(dst); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return false
+	}
+	return true
+}
+
+func (s *Server) handleAssetCreate(w http.ResponseWriter, r *http.Request) {
+	var req core.CreateAssetRequest
+	if !decodeJSON(w, r, &req) {
+		return
+	}
+	asset, err := s.service.CreateAsset(req)
+	if err != nil {
+		writeError(w, httpStatusForError(err), err.Error())
+		return
+	}
+	writeResponse(w, http.StatusCreated, asset)
+}
+
+func (s *Server) handleAssetUpdate(w http.ResponseWriter, r *http.Request) {
+	var req core.UpdateAssetRequest
+	if !decodeJSON(w, r, &req) {
+		return
+	}
+	req.ID = r.PathValue("id") // the path id is authoritative
+	asset, err := s.service.UpdateAsset(req)
+	if err != nil {
+		writeError(w, httpStatusForError(err), err.Error())
+		return
+	}
+	writeResponse(w, http.StatusOK, asset)
+}
+
+func (s *Server) handleAssetDelete(w http.ResponseWriter, r *http.Request) {
+	req := core.DeleteAssetRequest{
+		ID:     r.PathValue("id"),
+		Source: r.URL.Query().Get("source"),
+	}
+	if err := s.service.DeleteAsset(req); err != nil {
+		writeError(w, httpStatusForError(err), err.Error())
+		return
+	}
+	writeResponse(w, http.StatusOK, map[string]string{"id": req.ID})
+}
+
+func (s *Server) handleRelationCreate(w http.ResponseWriter, r *http.Request) {
+	var req core.CreateRelationRequest
+	if !decodeJSON(w, r, &req) {
+		return
+	}
+	relation, err := s.service.CreateRelation(req)
+	if err != nil {
+		writeError(w, httpStatusForError(err), err.Error())
+		return
+	}
+	writeResponse(w, http.StatusCreated, relation)
+}
+
+func (s *Server) handleRelationDelete(w http.ResponseWriter, r *http.Request) {
+	req := core.DeleteRelationRequest{
+		ID:     r.PathValue("id"),
+		Source: r.URL.Query().Get("source"),
+	}
+	if err := s.service.DeleteRelation(req); err != nil {
+		writeError(w, httpStatusForError(err), err.Error())
+		return
+	}
+	writeResponse(w, http.StatusOK, map[string]string{"id": req.ID})
+}

--- a/internal/httpapi/write_test.go
+++ b/internal/httpapi/write_test.go
@@ -1,0 +1,141 @@
+package httpapi
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/e7217/edg/internal/core"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newHTTPTestServer builds a Server with a MetadataService over the same store,
+// using an empty template loader and no event publisher (publish is nil-safe).
+func newHTTPTestServer(store *core.Store, opts Options) *Server {
+	service := core.NewMetadataService(store, core.NewTemplateLoader(), nil, core.ConstraintsEnforcementWarn)
+	return NewServer(store, service, opts)
+}
+
+func doJSON(t *testing.T, method, url, token string, body any) (int, testResponse) {
+	t.Helper()
+
+	var buf bytes.Buffer
+	if body != nil {
+		require.NoError(t, json.NewEncoder(&buf).Encode(body))
+	}
+	req, err := http.NewRequest(method, url, &buf)
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	res, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer res.Body.Close()
+
+	var resp testResponse
+	require.NoError(t, json.NewDecoder(res.Body).Decode(&resp))
+	return res.StatusCode, resp
+}
+
+const writeTestToken = "test-token"
+
+func TestServerWriteAssets(t *testing.T) {
+	store := newHTTPTestStore(t)
+	server := httptest.NewServer(newHTTPTestServer(store, Options{Token: writeTestToken}).Handler())
+	t.Cleanup(server.Close)
+
+	// create
+	status, resp := doJSON(t, http.MethodPost, server.URL+"/api/v1/assets", writeTestToken, core.CreateAssetRequest{Name: "pump-9"})
+	require.Equal(t, http.StatusCreated, status)
+	require.True(t, resp.Success)
+	var created core.Asset
+	require.NoError(t, json.Unmarshal(resp.Data, &created))
+	require.NotEmpty(t, created.ID)
+	assert.Equal(t, "pump-9", created.Name)
+
+	// duplicate name -> 409
+	status, resp = doJSON(t, http.MethodPost, server.URL+"/api/v1/assets", writeTestToken, core.CreateAssetRequest{Name: "pump-9"})
+	require.Equal(t, http.StatusConflict, status)
+	assert.Contains(t, resp.Error, "already exists")
+
+	// missing name -> 400
+	status, _ = doJSON(t, http.MethodPost, server.URL+"/api/v1/assets", writeTestToken, core.CreateAssetRequest{})
+	require.Equal(t, http.StatusBadRequest, status)
+
+	// update (path id is authoritative)
+	status, resp = doJSON(t, http.MethodPut, server.URL+"/api/v1/assets/"+created.ID, writeTestToken, core.UpdateAssetRequest{Name: "pump-9-renamed"})
+	require.Equal(t, http.StatusOK, status)
+	var updated core.Asset
+	require.NoError(t, json.Unmarshal(resp.Data, &updated))
+	assert.Equal(t, "pump-9-renamed", updated.Name)
+
+	// update missing -> 404
+	status, _ = doJSON(t, http.MethodPut, server.URL+"/api/v1/assets/nope", writeTestToken, core.UpdateAssetRequest{Name: "x"})
+	require.Equal(t, http.StatusNotFound, status)
+
+	// delete
+	status, _ = doJSON(t, http.MethodDelete, server.URL+"/api/v1/assets/"+created.ID, writeTestToken, nil)
+	require.Equal(t, http.StatusOK, status)
+
+	got, err := store.GetAsset(created.ID)
+	require.NoError(t, err)
+	assert.Nil(t, got)
+}
+
+func TestServerWriteRelations(t *testing.T) {
+	store := newHTTPTestStore(t)
+	server := httptest.NewServer(newHTTPTestServer(store, Options{Token: writeTestToken}).Handler())
+	t.Cleanup(server.Close)
+
+	// create a relation between two existing assets
+	status, resp := doJSON(t, http.MethodPost, server.URL+"/api/v1/relations", writeTestToken, core.CreateRelationRequest{
+		SourceAssetID: "sensor-1", TargetAssetID: "line-1", RelationType: core.RelationLocatedIn,
+	})
+	require.Equal(t, http.StatusCreated, status)
+	var rel core.AssetRelation
+	require.NoError(t, json.Unmarshal(resp.Data, &rel))
+	require.NotEmpty(t, rel.ID)
+
+	// invalid relation_type -> 400
+	status, _ = doJSON(t, http.MethodPost, server.URL+"/api/v1/relations", writeTestToken, core.CreateRelationRequest{
+		SourceAssetID: "sensor-1", TargetAssetID: "line-1", RelationType: "bogus",
+	})
+	require.Equal(t, http.StatusBadRequest, status)
+
+	// delete
+	status, _ = doJSON(t, http.MethodDelete, server.URL+"/api/v1/relations/"+rel.ID, writeTestToken, nil)
+	require.Equal(t, http.StatusOK, status)
+}
+
+func TestServerWriteRequiresTokenWhenUnset(t *testing.T) {
+	store := newHTTPTestStore(t)
+	server := httptest.NewServer(newHTTPTestServer(store, Options{}).Handler())
+	t.Cleanup(server.Close)
+
+	// writes are rejected when no token is configured
+	status, resp := doJSON(t, http.MethodPost, server.URL+"/api/v1/assets", "", core.CreateAssetRequest{Name: "x"})
+	require.Equal(t, http.StatusUnauthorized, status)
+	assert.Contains(t, resp.Error, "token")
+
+	// reads remain open
+	status, _ = getJSON(t, server.URL+"/api/v1/assets", "")
+	require.Equal(t, http.StatusOK, status)
+}
+
+func TestServerWriteWithToken(t *testing.T) {
+	store := newHTTPTestStore(t)
+	server := httptest.NewServer(newHTTPTestServer(store, Options{Token: "secret"}).Handler())
+	t.Cleanup(server.Close)
+
+	// without token -> 401
+	status, _ := doJSON(t, http.MethodPost, server.URL+"/api/v1/assets", "", core.CreateAssetRequest{Name: "tok-asset"})
+	require.Equal(t, http.StatusUnauthorized, status)
+
+	// with token -> 201
+	status, _ = doJSON(t, http.MethodPost, server.URL+"/api/v1/assets", "secret", core.CreateAssetRequest{Name: "tok-asset"})
+	require.Equal(t, http.StatusCreated, status)
+}


### PR DESCRIPTION
## Summary

**Phase 3** of the [unified master-data control design](https://github.com/e7217/edg/blob/main/docs/superpowers/specs/2026-06-18-unified-master-data-control-design.md): make the HTTP API a real control surface by adding write endpoints, all routed through the Phase 1 `MetadataService`.

## What changed

- **Write endpoints** (`internal/httpapi/write.go`): `POST/PUT/DELETE /api/v1/assets[/{id}]`, `POST/DELETE /api/v1/relations[/{id}]`. Each calls `MetadataService`, so HTTP writes get the **same** validation / constraint enforcement / change events as the NATS path.
- **Typed error → HTTP status** via `core.KindOf`: 400 validation, 404 not found, 409 conflict, 422 constraint, 500 other.
- **Auth hardening**: reads stay anonymous when no token is configured, but write methods **always require a non-empty bearer token**. CORS now advertises `POST/PUT/DELETE`.
- `main.go` builds one `MetadataService` and injects it into `httpapi.NewServer` (signature now `NewServer(store, service, opts)`).
- Updated `docs/USER_GUIDE.md`.

## Tests

- New `write_test.go`: create/update/delete assets & relations over HTTP, status mapping (409/400/404), and the write-requires-token rule (no token → write 401, read 200; token set → correct bearer → 201).
- Existing read/auth tests updated to the new `NewServer` signature and still pass.

## Verification

```
go build ./...   # ok
go vet ./...      # clean
go test ./...     # all packages ok
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HUdtJkgqoi5UmN3fAifmAu