### PR TITLE
feat(core): make templates DB-authoritative with import/export (Phase 4)

### DIFF
--- a/cmd/core/main.go
+++ b/cmd/core/main.go
@@ -30,6 +30,8 @@ func main() {
 	versionFlag := flag.Bool("version", false, "Print version information and exit")
 	migrateDownFlag := flag.Int("migrate-down", 0, "Rollback metadata DB by N migration steps and exit")
 	checkConstraintsFlag := flag.Bool("check-constraints", false, "Check catalog template constraints and exit")
+	importTemplatesFlag := flag.String("import-templates", "", "Import templates from a directory into the metadata DB and exit")
+	exportTemplatesFlag := flag.String("export-templates", "", "Export templates from the metadata DB to a directory and exit")
 	configFlag := flag.String("config", os.Getenv("EDG_CORE_CONFIG"), "Path to core configuration file")
 	flag.Parse()
 
@@ -63,6 +65,20 @@ func main() {
 			log.Fatalf("Failed to rollback metadata DB: %v", err)
 		}
 		log.Printf("[Core] Rolled back metadata DB by %d migration step(s)", *migrateDownFlag)
+		os.Exit(0)
+	}
+
+	if *importTemplatesFlag != "" {
+		if err := runImportTemplates(cfg, *importTemplatesFlag); err != nil {
+			log.Fatalf("Failed to import templates: %v", err)
+		}
+		os.Exit(0)
+	}
+
+	if *exportTemplatesFlag != "" {
+		if err := runExportTemplates(cfg, *exportTemplatesFlag); err != nil {
+			log.Fatalf("Failed to export templates: %v", err)
+		}
 		os.Exit(0)
 	}
 
@@ -148,10 +164,15 @@ func main() {
 	}
 	defer store.Close()
 
-	// 5. Initialize template loader
-	loader := core.NewTemplateLoader()
-	if err := loader.LoadFromDir(cfg.Templates.Dir); err != nil {
-		log.Printf("[Core] Warning: Failed to load templates: %v", err)
+	// 5. Initialize template loader (DB-authoritative; seed from dir on empty DB)
+	loader, err := core.NewTemplateLoaderWithStore(store)
+	if err != nil {
+		log.Fatalf("Failed to load templates from store: %v", err)
+	}
+	if loader.Count() == 0 {
+		if err := loader.LoadFromDir(cfg.Templates.Dir); err != nil {
+			log.Printf("[Core] Warning: Failed to seed templates from %s: %v", cfg.Templates.Dir, err)
+		}
 	}
 	log.Printf("[Core] Loaded %d templates", loader.Count())
 
@@ -250,12 +271,53 @@ func checkConstraints(cfg core.CoreConfig) (core.ConstraintsReport, error) {
 	}
 	defer store.Close()
 
-	loader := core.NewTemplateLoader()
-	if err := loader.LoadFromDir(cfg.Templates.Dir); err != nil {
+	loader, err := core.NewTemplateLoaderWithStore(store)
+	if err != nil {
 		return core.ConstraintsReport{}, err
+	}
+	if loader.Count() == 0 {
+		if err := loader.LoadFromDir(cfg.Templates.Dir); err != nil {
+			return core.ConstraintsReport{}, err
+		}
 	}
 
 	return core.NewConstraintsEvaluator(loader).CheckAll(store)
+}
+
+func runImportTemplates(cfg core.CoreConfig, dir string) error {
+	store, err := core.NewStoreWithMigrations(cfg.Storage.MetadataDB, cfg.Storage.AutoMigrate)
+	if err != nil {
+		return err
+	}
+	defer store.Close()
+
+	loader, err := core.NewTemplateLoaderWithStore(store)
+	if err != nil {
+		return err
+	}
+	if err := loader.LoadFromDir(dir); err != nil {
+		return err
+	}
+	log.Printf("[Core] Imported templates from %s (%d total)", dir, loader.Count())
+	return nil
+}
+
+func runExportTemplates(cfg core.CoreConfig, dir string) error {
+	store, err := core.NewStoreWithMigrations(cfg.Storage.MetadataDB, cfg.Storage.AutoMigrate)
+	if err != nil {
+		return err
+	}
+	defer store.Close()
+
+	loader, err := core.NewTemplateLoaderWithStore(store)
+	if err != nil {
+		return err
+	}
+	if err := loader.ExportToDir(dir); err != nil {
+		return err
+	}
+	log.Printf("[Core] Exported %d templates to %s", loader.Count(), dir)
+	return nil
 }
 
 func discoverConfigPath() string {

--- a/deploy/configs/core/config.dev.yaml
+++ b/deploy/configs/core/config.dev.yaml
@@ -14,7 +14,6 @@ storage:
 
 templates:
   dir: ./templates
-  auto_reload: true
 
 # Behavior for data whose asset_id has no declared master-data record.
 # pass_through: publish un-enriched to validated (default).

--- a/deploy/configs/core/config.prod.yaml
+++ b/deploy/configs/core/config.prod.yaml
@@ -14,7 +14,6 @@ storage:
 
 templates:
   dir: /etc/edg/templates
-  auto_reload: false
 
 alarm:
   window_seconds: 5

--- a/deploy/configs/core/config.staging.yaml
+++ b/deploy/configs/core/config.staging.yaml
@@ -14,7 +14,6 @@ storage:
 
 templates:
   dir: /etc/edg/templates
-  auto_reload: true
 
 alarm:
   window_seconds: 5

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -64,8 +64,17 @@ INSTALL_DIR=/custom/path ./install.sh
 ### EDG Core
 - **Data Storage**: `./data/metadata.db` (auto-created)
 - **Schema Migrations**: embedded migrations run automatically on startup
-- **Templates**: `./templates/` (optional)
+- **Templates**: stored in SQLite (authoritative). The `templates.dir` directory
+  (default `./templates/`) is **seed-imported on first boot** when the DB has no
+  templates, and is the default target for the import/export commands below.
 - **Config file**: set `EDG_CORE_CONFIG` or pass `--config` to choose a core YAML file.
+
+Manage templates as files without running the server:
+
+```bash
+edg-core --import-templates ./templates   # YAML files -> SQLite (upsert)
+edg-core --export-templates ./out          # SQLite -> one YAML per template
+```
 
 **JetStream reliability defaults:**
 ```yaml

--- a/internal/core/config.go
+++ b/internal/core/config.go
@@ -49,8 +49,10 @@ type StorageConfig struct {
 }
 
 type TemplateConfig struct {
-	Dir        string `yaml:"dir"`
-	AutoReload bool   `yaml:"auto_reload"`
+	// Dir is the seed/import directory for templates. Templates are stored in
+	// SQLite; this directory is imported into an empty DB on first boot and is
+	// the default target for --import-templates / --export-templates.
+	Dir string `yaml:"dir"`
 }
 
 type LoggingConfig struct {
@@ -120,8 +122,7 @@ func DefaultCoreConfig() CoreConfig {
 			AutoMigrate:   true,
 		},
 		Templates: TemplateConfig{
-			Dir:        "./templates",
-			AutoReload: true,
+			Dir: "./templates",
 		},
 		Logging: LoggingConfig{
 			Level:  "info",

--- a/internal/core/loader.go
+++ b/internal/core/loader.go
@@ -9,20 +9,84 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-// TemplateLoader loads asset templates from YAML files
+// TemplateLoader is an in-memory cache of asset templates. When backed by a
+// Store (NewTemplateLoaderWithStore), writes are persisted to SQLite while the
+// cache remains the authoritative read path, so the relation-create constraint
+// hot path stays in-memory.
 type TemplateLoader struct {
 	mu        sync.RWMutex
+	store     *Store
 	templates map[string]*AssetTemplate
 }
 
-// NewTemplateLoader creates a new loader
+// NewTemplateLoader creates an in-memory-only loader (no persistence).
 func NewTemplateLoader() *TemplateLoader {
 	return &TemplateLoader{
 		templates: make(map[string]*AssetTemplate),
 	}
 }
 
-// LoadFromDir loads all YAML templates from a directory
+// NewTemplateLoaderWithStore creates a loader backed by the given Store and
+// populates its cache from the database.
+func NewTemplateLoaderWithStore(store *Store) (*TemplateLoader, error) {
+	l := &TemplateLoader{
+		store:     store,
+		templates: make(map[string]*AssetTemplate),
+	}
+	if err := l.reloadFromStore(); err != nil {
+		return nil, err
+	}
+	return l, nil
+}
+
+func (l *TemplateLoader) reloadFromStore() error {
+	if l.store == nil {
+		return nil
+	}
+	templates, err := l.store.ListTemplates()
+	if err != nil {
+		return fmt.Errorf("failed to load templates from store: %w", err)
+	}
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.templates = make(map[string]*AssetTemplate, len(templates))
+	for _, t := range templates {
+		l.templates[t.Name] = t
+	}
+	return nil
+}
+
+// Upsert persists a template (when store-backed) and updates the cache.
+func (l *TemplateLoader) Upsert(template *AssetTemplate) error {
+	if template == nil || template.Name == "" {
+		return fmt.Errorf("template name is required")
+	}
+	if l.store != nil {
+		if err := l.store.UpsertTemplate(template); err != nil {
+			return err
+		}
+	}
+	l.mu.Lock()
+	l.templates[template.Name] = template
+	l.mu.Unlock()
+	return nil
+}
+
+// Delete removes a template from the store (when store-backed) and the cache.
+func (l *TemplateLoader) Delete(name string) error {
+	if l.store != nil {
+		if err := l.store.DeleteTemplate(name); err != nil {
+			return err
+		}
+	}
+	l.mu.Lock()
+	delete(l.templates, name)
+	l.mu.Unlock()
+	return nil
+}
+
+// LoadFromDir imports all YAML templates from a directory (persisting to the
+// store when store-backed) and validates cross-template constraints.
 func (l *TemplateLoader) LoadFromDir(dir string) error {
 	entries, err := os.ReadDir(dir)
 	if err != nil {
@@ -48,7 +112,7 @@ func (l *TemplateLoader) LoadFromDir(dir string) error {
 	return validateTemplateConstraints(l)
 }
 
-// LoadFromFile loads a template from a single YAML file
+// LoadFromFile imports a single YAML template file.
 func (l *TemplateLoader) LoadFromFile(path string) error {
 	data, err := os.ReadFile(path)
 	if err != nil {
@@ -64,10 +128,24 @@ func (l *TemplateLoader) LoadFromFile(path string) error {
 		return fmt.Errorf("template name is missing: %s", path)
 	}
 
-	l.mu.Lock()
-	l.templates[template.Name] = &template
-	l.mu.Unlock()
+	return l.Upsert(&template)
+}
 
+// ExportToDir writes each template to dir/<name>.yaml (round-trips with import).
+func (l *TemplateLoader) ExportToDir(dir string) error {
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("failed to create export directory: %w", err)
+	}
+	for _, t := range l.List() {
+		data, err := yaml.Marshal(t)
+		if err != nil {
+			return fmt.Errorf("failed to encode template %s: %w", t.Name, err)
+		}
+		path := filepath.Join(dir, t.Name+".yaml")
+		if err := os.WriteFile(path, data, 0o644); err != nil {
+			return fmt.Errorf("failed to write template %s: %w", t.Name, err)
+		}
+	}
 	return nil
 }
 

--- a/internal/core/migrate_test.go
+++ b/internal/core/migrate_test.go
@@ -21,6 +21,9 @@ func TestRunMigrationsCreatesSchema(t *testing.T) {
 
 	assert.True(t, tableExists(t, db, "assets"))
 	assert.True(t, tableExists(t, db, "asset_relations"))
+	assert.True(t, tableExists(t, db, "templates"))
+	assert.True(t, tableExists(t, db, "template_resources"))
+	assert.True(t, tableExists(t, db, "template_constraints"))
 	assert.True(t, columnExists(t, db, "assets", "external_ids"))
 	assert.True(t, columnExists(t, db, "assets", "source"))
 	assert.True(t, columnExists(t, db, "assets", "attributes"))
@@ -64,19 +67,30 @@ func TestMigrationDownSteps(t *testing.T) {
 	defer db.Close()
 
 	require.NoError(t, runMigrations(db))
+	require.True(t, tableExists(t, db, "templates"))
 	require.True(t, columnExists(t, db, "assets", "source"))
 	require.True(t, indexExists(t, db, "idx_relations_source_type"))
 
+	// Undo 0004 (templates).
+	require.NoError(t, runMigrationSteps(db, -1))
+	assert.False(t, tableExists(t, db, "templates"))
+	assert.False(t, tableExists(t, db, "template_resources"))
+	assert.True(t, indexExists(t, db, "idx_relations_source_type"))
+	assert.True(t, tableExists(t, db, "assets"))
+
+	// Undo 0003 (relation indexes).
 	require.NoError(t, runMigrationSteps(db, -1))
 	assert.False(t, indexExists(t, db, "idx_relations_source_type"))
 	assert.False(t, indexExists(t, db, "idx_relations_target_type"))
 	assert.True(t, columnExists(t, db, "assets", "source"))
 	assert.True(t, tableExists(t, db, "assets"))
 
+	// Undo 0002 (asset extensions).
 	require.NoError(t, runMigrationSteps(db, -1))
 	assert.False(t, columnExists(t, db, "assets", "source"))
 	assert.True(t, tableExists(t, db, "assets"))
 
+	// Undo 0001 (init).
 	require.NoError(t, runMigrationSteps(db, -1))
 	assert.False(t, tableExists(t, db, "assets"))
 	assert.False(t, tableExists(t, db, "asset_relations"))

--- a/internal/core/migrations/0004_templates.down.sql
+++ b/internal/core/migrations/0004_templates.down.sql
@@ -1,0 +1,4 @@
+DROP INDEX IF EXISTS idx_template_constraints_tmpl;
+DROP TABLE IF EXISTS template_constraints;
+DROP TABLE IF EXISTS template_resources;
+DROP TABLE IF EXISTS templates;

--- a/internal/core/migrations/0004_templates.up.sql
+++ b/internal/core/migrations/0004_templates.up.sql
@@ -1,0 +1,27 @@
+CREATE TABLE IF NOT EXISTS templates (
+	name TEXT PRIMARY KEY,
+	created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+	updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS template_resources (
+	template_name TEXT NOT NULL,
+	name TEXT NOT NULL,
+	value_type TEXT NOT NULL,
+	unit TEXT NOT NULL DEFAULT '',
+	PRIMARY KEY (template_name, name),
+	FOREIGN KEY (template_name) REFERENCES templates(name) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS template_constraints (
+	id INTEGER PRIMARY KEY AUTOINCREMENT,
+	template_name TEXT NOT NULL,
+	kind TEXT NOT NULL CHECK (kind IN ('required', 'forbidden')),
+	relation_type TEXT NOT NULL,
+	target_template TEXT NOT NULL,
+	min_count INTEGER,
+	max_count INTEGER,
+	FOREIGN KEY (template_name) REFERENCES templates(name) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_template_constraints_tmpl ON template_constraints(template_name);

--- a/internal/core/store_templates.go
+++ b/internal/core/store_templates.go
@@ -1,0 +1,165 @@
+package core
+
+import "database/sql"
+
+// UpsertTemplate persists a template and its resources/constraints atomically,
+// replacing any existing template with the same name. created_at is preserved.
+func (s *Store) UpsertTemplate(t *AssetTemplate) error {
+	tx, err := s.db.Begin()
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+
+	if _, err := tx.Exec(
+		`INSERT INTO templates (name, updated_at) VALUES (?, CURRENT_TIMESTAMP)
+		 ON CONFLICT(name) DO UPDATE SET updated_at = CURRENT_TIMESTAMP`,
+		t.Name,
+	); err != nil {
+		return err
+	}
+	if _, err := tx.Exec(`DELETE FROM template_resources WHERE template_name = ?`, t.Name); err != nil {
+		return err
+	}
+	if _, err := tx.Exec(`DELETE FROM template_constraints WHERE template_name = ?`, t.Name); err != nil {
+		return err
+	}
+	for _, r := range t.Resources {
+		if _, err := tx.Exec(
+			`INSERT INTO template_resources (template_name, name, value_type, unit) VALUES (?, ?, ?, ?)`,
+			t.Name, r.Name, r.ValueType, r.Unit,
+		); err != nil {
+			return err
+		}
+	}
+	if err := insertTemplateConstraints(tx, t.Name, "required", t.Constraints.RequiredRelations); err != nil {
+		return err
+	}
+	if err := insertTemplateConstraints(tx, t.Name, "forbidden", t.Constraints.ForbiddenRelations); err != nil {
+		return err
+	}
+	return tx.Commit()
+}
+
+func insertTemplateConstraints(tx *sql.Tx, templateName, kind string, constraints []RelationConstraint) error {
+	for _, c := range constraints {
+		if _, err := tx.Exec(
+			`INSERT INTO template_constraints (template_name, kind, relation_type, target_template, min_count, max_count)
+			 VALUES (?, ?, ?, ?, ?, ?)`,
+			templateName, kind, string(c.Type), c.TargetTemplate, nullableInt(c.Min), nullableInt(c.Max),
+		); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func nullableInt(v *int) interface{} {
+	if v == nil {
+		return nil
+	}
+	return *v
+}
+
+// GetTemplate returns the template by name, or nil if it does not exist.
+func (s *Store) GetTemplate(name string) (*AssetTemplate, error) {
+	var found string
+	err := s.db.QueryRow(`SELECT name FROM templates WHERE name = ?`, name).Scan(&found)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	t := &AssetTemplate{Name: name}
+
+	rows, err := s.db.Query(
+		`SELECT name, value_type, unit FROM template_resources WHERE template_name = ? ORDER BY name`, name)
+	if err != nil {
+		return nil, err
+	}
+	for rows.Next() {
+		var r AssetResource
+		if err := rows.Scan(&r.Name, &r.ValueType, &r.Unit); err != nil {
+			rows.Close()
+			return nil, err
+		}
+		t.Resources = append(t.Resources, r)
+	}
+	rows.Close()
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	crows, err := s.db.Query(
+		`SELECT kind, relation_type, target_template, min_count, max_count
+		 FROM template_constraints WHERE template_name = ? ORDER BY id`, name)
+	if err != nil {
+		return nil, err
+	}
+	defer crows.Close()
+	for crows.Next() {
+		var kind, relType string
+		var c RelationConstraint
+		var minV, maxV sql.NullInt64
+		if err := crows.Scan(&kind, &relType, &c.TargetTemplate, &minV, &maxV); err != nil {
+			return nil, err
+		}
+		c.Type = RelationType(relType)
+		if minV.Valid {
+			v := int(minV.Int64)
+			c.Min = &v
+		}
+		if maxV.Valid {
+			v := int(maxV.Int64)
+			c.Max = &v
+		}
+		if kind == "required" {
+			t.Constraints.RequiredRelations = append(t.Constraints.RequiredRelations, c)
+		} else {
+			t.Constraints.ForbiddenRelations = append(t.Constraints.ForbiddenRelations, c)
+		}
+	}
+	return t, crows.Err()
+}
+
+// ListTemplates returns all templates ordered by name.
+func (s *Store) ListTemplates() ([]*AssetTemplate, error) {
+	rows, err := s.db.Query(`SELECT name FROM templates ORDER BY name`)
+	if err != nil {
+		return nil, err
+	}
+	var names []string
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			rows.Close()
+			return nil, err
+		}
+		names = append(names, name)
+	}
+	rows.Close()
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	templates := make([]*AssetTemplate, 0, len(names))
+	for _, name := range names {
+		t, err := s.GetTemplate(name)
+		if err != nil {
+			return nil, err
+		}
+		if t != nil {
+			templates = append(templates, t)
+		}
+	}
+	return templates, nil
+}
+
+// DeleteTemplate removes a template and its children (CASCADE). It is a no-op if
+// the template does not exist.
+func (s *Store) DeleteTemplate(name string) error {
+	_, err := s.db.Exec(`DELETE FROM templates WHERE name = ?`, name)
+	return err
+}

--- a/internal/core/store_templates_test.go
+++ b/internal/core/store_templates_test.go
@@ -1,0 +1,167 @@
+package core
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func tmplIntPtr(v int) *int { return &v }
+
+func sampleTemplate() *AssetTemplate {
+	return &AssetTemplate{
+		Name: "temp-sensor",
+		Resources: []AssetResource{
+			{Name: "temperature", ValueType: ValueTypeNumber, Unit: "C"},
+			{Name: "status", ValueType: ValueTypeText},
+		},
+		Constraints: TemplateConstraints{
+			RequiredRelations: []RelationConstraint{
+				{Type: RelationPartOf, TargetTemplate: "equipment", Min: tmplIntPtr(1), Max: tmplIntPtr(1)},
+			},
+			ForbiddenRelations: []RelationConstraint{
+				{Type: RelationConnectedTo, TargetTemplate: "factory"},
+			},
+		},
+	}
+}
+
+func TestStoreTemplate_UpsertGetRoundTrip(t *testing.T) {
+	store, err := NewStore(":memory:")
+	require.NoError(t, err)
+	defer store.Close()
+
+	require.NoError(t, store.UpsertTemplate(sampleTemplate()))
+
+	got, err := store.GetTemplate("temp-sensor")
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, "temp-sensor", got.Name)
+
+	require.Len(t, got.Resources, 2)
+	assert.Equal(t, "status", got.Resources[0].Name) // ordered by name
+	assert.Equal(t, "temperature", got.Resources[1].Name)
+	assert.Equal(t, ValueTypeNumber, got.Resources[1].ValueType)
+	assert.Equal(t, "C", got.Resources[1].Unit)
+
+	require.Len(t, got.Constraints.RequiredRelations, 1)
+	rc := got.Constraints.RequiredRelations[0]
+	assert.Equal(t, RelationPartOf, rc.Type)
+	assert.Equal(t, "equipment", rc.TargetTemplate)
+	require.NotNil(t, rc.Min)
+	assert.Equal(t, 1, *rc.Min)
+	require.NotNil(t, rc.Max)
+	assert.Equal(t, 1, *rc.Max)
+
+	require.Len(t, got.Constraints.ForbiddenRelations, 1)
+	fc := got.Constraints.ForbiddenRelations[0]
+	assert.Equal(t, RelationConnectedTo, fc.Type)
+	assert.Nil(t, fc.Min)
+	assert.Nil(t, fc.Max)
+}
+
+func TestStoreTemplate_UpsertReplacesChildren(t *testing.T) {
+	store, err := NewStore(":memory:")
+	require.NoError(t, err)
+	defer store.Close()
+
+	require.NoError(t, store.UpsertTemplate(&AssetTemplate{
+		Name:      "t",
+		Resources: []AssetResource{{Name: "a", ValueType: ValueTypeNumber}, {Name: "b", ValueType: ValueTypeText}},
+	}))
+	// Re-upsert with one resource: children must be replaced, not appended.
+	require.NoError(t, store.UpsertTemplate(&AssetTemplate{
+		Name:      "t",
+		Resources: []AssetResource{{Name: "c", ValueType: ValueTypeFlag}},
+	}))
+
+	got, err := store.GetTemplate("t")
+	require.NoError(t, err)
+	require.Len(t, got.Resources, 1)
+	assert.Equal(t, "c", got.Resources[0].Name)
+}
+
+func TestStoreTemplate_ListAndDelete(t *testing.T) {
+	store, err := NewStore(":memory:")
+	require.NoError(t, err)
+	defer store.Close()
+
+	require.NoError(t, store.UpsertTemplate(&AssetTemplate{Name: "b"}))
+	require.NoError(t, store.UpsertTemplate(&AssetTemplate{Name: "a"}))
+
+	list, err := store.ListTemplates()
+	require.NoError(t, err)
+	require.Len(t, list, 2)
+	assert.Equal(t, "a", list[0].Name) // ordered by name
+	assert.Equal(t, "b", list[1].Name)
+
+	require.NoError(t, store.DeleteTemplate("a"))
+	got, err := store.GetTemplate("a")
+	require.NoError(t, err)
+	assert.Nil(t, got)
+
+	list, err = store.ListTemplates()
+	require.NoError(t, err)
+	require.Len(t, list, 1)
+}
+
+func TestStoreTemplate_GetMissing(t *testing.T) {
+	store, err := NewStore(":memory:")
+	require.NoError(t, err)
+	defer store.Close()
+
+	got, err := store.GetTemplate("nope")
+	require.NoError(t, err)
+	assert.Nil(t, got)
+}
+
+func TestTemplateLoader_StoreBackedPersistsAndReloads(t *testing.T) {
+	store, err := NewStore(":memory:")
+	require.NoError(t, err)
+	defer store.Close()
+
+	loader, err := NewTemplateLoaderWithStore(store)
+	require.NoError(t, err)
+	require.Equal(t, 0, loader.Count())
+
+	require.NoError(t, loader.Upsert(sampleTemplate()))
+	assert.True(t, loader.Exists("temp-sensor"))
+
+	// A fresh loader over the same store reloads the persisted template.
+	reloaded, err := NewTemplateLoaderWithStore(store)
+	require.NoError(t, err)
+	assert.Equal(t, 1, reloaded.Count())
+	got := reloaded.Get("temp-sensor")
+	require.NotNil(t, got)
+	require.Len(t, got.Resources, 2)
+
+	// Delete persists too.
+	require.NoError(t, loader.Delete("temp-sensor"))
+	again, err := NewTemplateLoaderWithStore(store)
+	require.NoError(t, err)
+	assert.Equal(t, 0, again.Count())
+}
+
+func TestTemplateLoader_ExportRoundTrip(t *testing.T) {
+	store, err := NewStore(":memory:")
+	require.NoError(t, err)
+	defer store.Close()
+
+	loader, err := NewTemplateLoaderWithStore(store)
+	require.NoError(t, err)
+	require.NoError(t, loader.Upsert(sampleTemplate()))
+
+	dir := t.TempDir()
+	require.NoError(t, loader.ExportToDir(dir))
+
+	// Import the exported YAML into a fresh in-memory loader.
+	fresh := NewTemplateLoader()
+	require.NoError(t, fresh.LoadFromFile(filepath.Join(dir, "temp-sensor.yaml")))
+	got := fresh.Get("temp-sensor")
+	require.NotNil(t, got)
+	require.Len(t, got.Resources, 2)
+	require.Len(t, got.Constraints.RequiredRelations, 1)
+	assert.Equal(t, "equipment", got.Constraints.RequiredRelations[0].TargetTemplate)
+}


### PR DESCRIPTION
## Summary

**Phase 4** of the [unified master-data control design](https://github.com/e7217/edg/blob/main/docs/superpowers/specs/2026-06-18-unified-master-data-control-design.md): asset templates move from an in-memory, file-loaded subsystem to **SQLite as the authoritative source**, so all master data (assets, relations, templates) lives in one store.

## What changed

- **Migration `0004`**: `templates`, `template_resources`, `template_constraints` tables.
- **Store template CRUD** (`store_templates.go`): `UpsertTemplate` (transactional, replaces children), `GetTemplate`, `ListTemplates`, `DeleteTemplate`.
- **`TemplateLoader` → DB-backed cache**: `NewTemplateLoaderWithStore` loads the cache from the DB; writes persist to SQLite. Reads (`Get/List/Exists/Count`) stay in-memory, so the relation-create constraint **hot path is unchanged**. `NewTemplateLoader()` stays in-memory-only for existing callers/tests.
- **Seed + CLI**: `main.go` seeds `templates.dir` into an empty DB on first boot; new `--import-templates <dir>` / `--export-templates <dir>` one-shot commands. `ExportToDir` round-trips with import.
- Removed the unused `auto_reload` config field.

## Scope note

HTTP template endpoints + per-template write CRUD are **deferred to Phase 5 (UI)**. The NATS `template.list` path now reads from the DB-backed loader.

## Tests

- Migration up/down (incl. new tables), Store CRUD round-trip (resources + constraints, nil min/max, child replacement), loader DB-persist+reload, export round-trip. Existing in-memory loader/constraints tests still pass.

## Verification

```
go build ./...   # ok
go vet ./...      # clean
go test ./...     # all packages ok
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HUdtJkgqoi5UmN3fAifmAu