### PR TITLE
feat(httpapi): add embedded operator UI + template/constraint reads (Phase 5)

### DIFF
--- a/cmd/core/main.go
+++ b/cmd/core/main.go
@@ -224,6 +224,7 @@ func main() {
 			Address:            cfg.HTTP.Address,
 			TokenEnv:           cfg.HTTP.TokenEnv,
 			CORSAllowedOrigins: cfg.HTTP.CORSAllowedOrigins,
+			WebUIEnabled:       cfg.HTTP.WebUIEnabled,
 			Version:            Version,
 			BuildTime:          BuildTime,
 			GitCommit:          GitCommit,

--- a/deploy/configs/core/config.dev.yaml
+++ b/deploy/configs/core/config.dev.yaml
@@ -31,6 +31,7 @@ http:
   enabled: true
   address: 127.0.0.1:8080
   token_env: EDG_HTTP_TOKEN
+  webui_enabled: true
   cors_allowed_origins:
     - http://localhost:3000
 

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -407,6 +407,25 @@ curl -H "Authorization: Bearer $EDG_HTTP_TOKEN" \
   "http://127.0.0.1:8080/api/v1/assets/factory-1/descendants?relation_types=partOf&max_depth=10"
 ```
 
+## Operator UI
+
+When `http.webui_enabled` is true, EDG Core serves a small built-in web UI at the
+HTTP root (`http://<address>/`) — no separate service or build step. It lists
+assets, relations, templates, and constraint violations, and provides simple
+create/delete forms.
+
+```yaml
+http:
+  enabled: true
+  webui_enabled: true
+```
+
+The UI is embedded in the binary (`go:embed`). Reads load anonymously; **writes
+require a bearer token** — paste it into the token field at the top of the page
+(stored in the browser's local storage). The UI refreshes on demand via a button;
+live push updates are a planned enhancement. Keep the HTTP address bound to
+localhost unless a token is configured.
+
 ## Monitoring
 
 - **NATS Monitor**: http://localhost:8222

--- a/internal/core/config.go
+++ b/internal/core/config.go
@@ -80,6 +80,7 @@ type HTTPConfig struct {
 	Address            string   `yaml:"address"`
 	TokenEnv           string   `yaml:"token_env"`
 	CORSAllowedOrigins []string `yaml:"cors_allowed_origins"`
+	WebUIEnabled       bool     `yaml:"webui_enabled"`
 }
 
 // SinkConfig configures the built-in VictoriaMetrics sink. When enabled, core

--- a/internal/core/meta_service.go
+++ b/internal/core/meta_service.go
@@ -31,6 +31,11 @@ func NewMetadataService(store *Store, loader *TemplateLoader, events *EventPubli
 	}
 }
 
+// CheckConstraints evaluates all template constraints across the catalog.
+func (s *MetadataService) CheckConstraints() (ConstraintsReport, error) {
+	return s.constraints.CheckAll(s.store)
+}
+
 func (s *MetadataService) CreateAsset(req CreateAssetRequest) (*Asset, error) {
 	if req.Name == "" {
 		return nil, newServiceError(ErrValidation, "name is required")

--- a/internal/httpapi/server.go
+++ b/internal/httpapi/server.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/e7217/edg/internal/core"
+	"github.com/e7217/edg/internal/webui"
 )
 
 const (
@@ -23,6 +24,7 @@ type Options struct {
 	Token              string
 	TokenEnv           string
 	CORSAllowedOrigins []string
+	WebUIEnabled       bool
 	Version            string
 	BuildTime          string
 	GitCommit          string
@@ -98,6 +100,9 @@ func (s *Server) buildHandler() http.Handler {
 	mux.HandleFunc("GET /api/v1/assets/{id}/subtree", s.handleSubtree)
 	mux.HandleFunc("GET /api/v1/assets/{id}/connected", s.handleConnected)
 	mux.HandleFunc("GET /api/v1/relations", s.handleRelations)
+	mux.HandleFunc("GET /api/v1/templates", s.handleTemplates)
+	mux.HandleFunc("GET /api/v1/templates/{name}", s.handleTemplate)
+	mux.HandleFunc("GET /api/v1/constraints", s.handleConstraints)
 
 	// Write endpoints (Phase 3). All mutations go through MetadataService so
 	// validation, constraint enforcement, and change events match the NATS path.
@@ -106,7 +111,44 @@ func (s *Server) buildHandler() http.Handler {
 	mux.HandleFunc("DELETE /api/v1/assets/{id}", s.handleAssetDelete)
 	mux.HandleFunc("POST /api/v1/relations", s.handleRelationCreate)
 	mux.HandleFunc("DELETE /api/v1/relations/{id}", s.handleRelationDelete)
+
+	// Embedded operator UI (Phase 5). Served at the root; the more specific
+	// /api/v1/... patterns take precedence in the Go 1.22 mux.
+	if s.options.WebUIEnabled {
+		mux.Handle("GET /", http.FileServerFS(webui.FS()))
+	}
 	return s.cors(s.auth(mux))
+}
+
+func (s *Server) handleTemplates(w http.ResponseWriter, r *http.Request) {
+	templates, err := s.store.ListTemplates()
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	writeResponse(w, http.StatusOK, templates)
+}
+
+func (s *Server) handleTemplate(w http.ResponseWriter, r *http.Request) {
+	template, err := s.store.GetTemplate(r.PathValue("name"))
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	if template == nil {
+		writeError(w, http.StatusNotFound, "template not found")
+		return
+	}
+	writeResponse(w, http.StatusOK, template)
+}
+
+func (s *Server) handleConstraints(w http.ResponseWriter, r *http.Request) {
+	report, err := s.service.CheckConstraints()
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	writeResponse(w, http.StatusOK, report)
 }
 
 func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {

--- a/internal/httpapi/webui_test.go
+++ b/internal/httpapi/webui_test.go
@@ -1,0 +1,74 @@
+package httpapi
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/e7217/edg/internal/core"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestServerTemplatesEndpoint(t *testing.T) {
+	store := newHTTPTestStore(t)
+	require.NoError(t, store.UpsertTemplate(&core.AssetTemplate{
+		Name:      "temp-sensor",
+		Resources: []core.AssetResource{{Name: "temperature", ValueType: core.ValueTypeNumber}},
+	}))
+	server := httptest.NewServer(newHTTPTestServer(store, Options{}).Handler())
+	t.Cleanup(server.Close)
+
+	status, resp := getJSON(t, server.URL+"/api/v1/templates", "")
+	require.Equal(t, http.StatusOK, status)
+	require.True(t, resp.Success)
+	var templates []*core.AssetTemplate
+	require.NoError(t, json.Unmarshal(resp.Data, &templates))
+	require.Len(t, templates, 1)
+	assert.Equal(t, "temp-sensor", templates[0].Name)
+
+	status, _ = getJSON(t, server.URL+"/api/v1/templates/temp-sensor", "")
+	require.Equal(t, http.StatusOK, status)
+
+	status, _ = getJSON(t, server.URL+"/api/v1/templates/nope", "")
+	require.Equal(t, http.StatusNotFound, status)
+}
+
+func TestServerConstraintsEndpoint(t *testing.T) {
+	store := newHTTPTestStore(t)
+	server := httptest.NewServer(newHTTPTestServer(store, Options{}).Handler())
+	t.Cleanup(server.Close)
+
+	status, resp := getJSON(t, server.URL+"/api/v1/constraints", "")
+	require.Equal(t, http.StatusOK, status)
+	require.True(t, resp.Success)
+}
+
+func TestServerWebUI(t *testing.T) {
+	store := newHTTPTestStore(t)
+
+	// Disabled: the root path is not served.
+	off := httptest.NewServer(newHTTPTestServer(store, Options{}).Handler())
+	t.Cleanup(off.Close)
+	res, err := http.Get(off.URL + "/")
+	require.NoError(t, err)
+	res.Body.Close()
+	assert.Equal(t, http.StatusNotFound, res.StatusCode)
+
+	// Enabled: the root serves the embedded HTML, and /api still works.
+	on := httptest.NewServer(newHTTPTestServer(store, Options{WebUIEnabled: true}).Handler())
+	t.Cleanup(on.Close)
+
+	res, err = http.Get(on.URL + "/")
+	require.NoError(t, err)
+	body, _ := io.ReadAll(res.Body)
+	res.Body.Close()
+	assert.Equal(t, http.StatusOK, res.StatusCode)
+	assert.Contains(t, res.Header.Get("Content-Type"), "text/html")
+	assert.Contains(t, string(body), "EDG Master Data")
+
+	status, _ := getJSON(t, on.URL+"/api/v1/health", "")
+	assert.Equal(t, http.StatusOK, status)
+}

--- a/internal/webui/dist/index.html
+++ b/internal/webui/dist/index.html
@@ -1,0 +1,159 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>EDG Master Data</title>
+<style>
+  :root { --bg:#0f1115; --panel:#1a1e26; --line:#2a2f3a; --fg:#e6e9ef; --muted:#9aa4b2; --accent:#4f8cff; --danger:#ff5c5c; }
+  * { box-sizing:border-box; }
+  body { margin:0; font:14px/1.5 system-ui,sans-serif; background:var(--bg); color:var(--fg); }
+  header { display:flex; gap:12px; align-items:center; flex-wrap:wrap; padding:12px 16px; background:var(--panel); border-bottom:1px solid var(--line); position:sticky; top:0; }
+  header h1 { font-size:16px; margin:0 12px 0 0; }
+  header input { background:#0c0e12; color:var(--fg); border:1px solid var(--line); border-radius:6px; padding:6px 8px; }
+  button { background:var(--accent); color:#fff; border:0; border-radius:6px; padding:6px 12px; cursor:pointer; }
+  button.secondary { background:#2a2f3a; }
+  button.danger { background:transparent; color:var(--danger); border:1px solid var(--danger); padding:2px 8px; }
+  main { padding:16px; display:grid; gap:16px; grid-template-columns:repeat(auto-fit,minmax(360px,1fr)); }
+  section { background:var(--panel); border:1px solid var(--line); border-radius:10px; padding:12px 14px; }
+  section h2 { font-size:14px; margin:0 0 10px; color:var(--muted); text-transform:uppercase; letter-spacing:.04em; }
+  table { width:100%; border-collapse:collapse; }
+  th,td { text-align:left; padding:6px 8px; border-bottom:1px solid var(--line); vertical-align:top; }
+  th { color:var(--muted); font-weight:600; }
+  form { display:flex; gap:8px; flex-wrap:wrap; margin-bottom:10px; }
+  form input,form select { background:#0c0e12; color:var(--fg); border:1px solid var(--line); border-radius:6px; padding:6px 8px; }
+  .muted { color:var(--muted); }
+  .pill { display:inline-block; padding:1px 8px; border-radius:999px; background:#23314f; color:#bcd0ff; font-size:12px; }
+</style>
+</head>
+<body>
+<header>
+  <h1>EDG Master Data</h1>
+  <input id="token" type="password" placeholder="bearer token (for writes)" size="28" />
+  <button id="refresh" class="secondary">Refresh</button>
+  <span id="status" class="muted"></span>
+</header>
+<main>
+  <section>
+    <h2>Assets</h2>
+    <form id="asset-form">
+      <input name="name" placeholder="name" required />
+      <input name="template_name" placeholder="template (optional)" />
+      <button type="submit">Create</button>
+    </form>
+    <table><thead><tr><th>ID</th><th>Name</th><th>Template</th><th></th></tr></thead><tbody id="assets"></tbody></table>
+  </section>
+  <section>
+    <h2>Relations</h2>
+    <form id="relation-form">
+      <input name="source_asset_id" placeholder="source id" required />
+      <input name="target_asset_id" placeholder="target id" required />
+      <select name="relation_type"><option>partOf</option><option>connectedTo</option><option>locatedIn</option></select>
+      <button type="submit">Create</button>
+    </form>
+    <table><thead><tr><th>Source</th><th>Type</th><th>Target</th><th></th></tr></thead><tbody id="relations"></tbody></table>
+  </section>
+  <section>
+    <h2>Templates</h2>
+    <table><thead><tr><th>Name</th><th>Resources</th><th>Constraints</th></tr></thead><tbody id="templates"></tbody></table>
+  </section>
+  <section>
+    <h2>Constraint Violations</h2>
+    <table><thead><tr><th>Asset</th><th>Type</th><th>Message</th></tr></thead><tbody id="violations"></tbody></table>
+  </section>
+</main>
+<script>
+const $ = (id) => document.getElementById(id);
+const token = () => $("token").value.trim();
+$("token").value = localStorage.getItem("edg_token") || "";
+$("token").addEventListener("change", () => localStorage.setItem("edg_token", token()));
+
+function setStatus(msg, isErr) { const s = $("status"); s.textContent = msg; s.style.color = isErr ? "#ff5c5c" : ""; }
+
+async function api(method, path, body) {
+  const headers = {};
+  if (body) headers["Content-Type"] = "application/json";
+  if (method !== "GET" && token()) headers["Authorization"] = "Bearer " + token();
+  const res = await fetch("/api/v1" + path, { method, headers, body: body ? JSON.stringify(body) : undefined });
+  const json = await res.json().catch(() => ({}));
+  if (!res.ok || json.success === false) throw new Error(json.error || ("HTTP " + res.status));
+  return json.data;
+}
+
+function cell(text) { const td = document.createElement("td"); td.textContent = text == null ? "" : String(text); return td; }
+function delBtn(onClick) {
+  const td = document.createElement("td");
+  const b = document.createElement("button"); b.className = "danger"; b.textContent = "delete";
+  b.onclick = onClick; td.appendChild(b); return td;
+}
+
+async function loadAssets() {
+  const assets = (await api("GET", "/assets?limit=500")) || [];
+  const tb = $("assets"); tb.innerHTML = "";
+  for (const a of assets) {
+    const tr = document.createElement("tr");
+    tr.append(cell(a.id), cell(a.name), cell(a.template_name || ""),
+      delBtn(() => mutate(() => api("DELETE", "/assets/" + encodeURIComponent(a.id)))));
+    tb.appendChild(tr);
+  }
+}
+async function loadRelations() {
+  const rels = (await api("GET", "/relations")) || [];
+  const tb = $("relations"); tb.innerHTML = "";
+  for (const r of rels) {
+    const tr = document.createElement("tr");
+    tr.append(cell(r.source_asset_id), cell(r.relation_type), cell(r.target_asset_id),
+      delBtn(() => mutate(() => api("DELETE", "/relations/" + encodeURIComponent(r.id)))));
+    tb.appendChild(tr);
+  }
+}
+async function loadTemplates() {
+  const tmpls = (await api("GET", "/templates")) || [];
+  const tb = $("templates"); tb.innerHTML = "";
+  for (const t of tmpls) {
+    const rc = (t.constraints && t.constraints.required_relations || []).length;
+    const fc = (t.constraints && t.constraints.forbidden_relations || []).length;
+    const tr = document.createElement("tr");
+    tr.append(cell(t.name), cell((t.resources || []).map(r => r.name).join(", ")), cell(`req ${rc} / forbid ${fc}`));
+    tb.appendChild(tr);
+  }
+}
+async function loadViolations() {
+  const report = await api("GET", "/constraints");
+  const tb = $("violations"); tb.innerHTML = "";
+  for (const v of (report && report.violations) || []) {
+    const tr = document.createElement("tr");
+    tr.append(cell(v.asset_name || v.asset_id), cell(v.constraint_type), cell(v.message));
+    tb.appendChild(tr);
+  }
+}
+
+async function refresh() {
+  setStatus("loading…");
+  try {
+    await Promise.all([loadAssets(), loadRelations(), loadTemplates(), loadViolations()]);
+    setStatus("updated " + new Date().toLocaleTimeString());
+  } catch (e) { setStatus(e.message, true); }
+}
+async function mutate(fn) {
+  try { await fn(); await refresh(); } catch (e) { setStatus(e.message, true); alert(e.message); }
+}
+
+$("refresh").onclick = refresh;
+$("asset-form").onsubmit = (e) => {
+  e.preventDefault();
+  const f = e.target;
+  mutate(() => api("POST", "/assets", { name: f.name.value, template_name: f.template_name.value || undefined }))
+    .then(() => f.reset());
+};
+$("relation-form").onsubmit = (e) => {
+  e.preventDefault();
+  const f = e.target;
+  mutate(() => api("POST", "/relations", {
+    source_asset_id: f.source_asset_id.value, target_asset_id: f.target_asset_id.value, relation_type: f.relation_type.value,
+  })).then(() => f.reset());
+};
+refresh();
+</script>
+</body>
+</html>

--- a/internal/webui/embed.go
+++ b/internal/webui/embed.go
@@ -1,0 +1,20 @@
+// Package webui embeds the static operator UI served by the core HTTP API.
+package webui
+
+import (
+	"embed"
+	"io/fs"
+)
+
+//go:embed dist/*
+var dist embed.FS
+
+// FS returns the embedded web UI assets rooted at the dist directory.
+func FS() fs.FS {
+	sub, err := fs.Sub(dist, "dist")
+	if err != nil {
+		// dist is embedded at build time; a failure here is a programming error.
+		panic(err)
+	}
+	return sub
+}


### PR DESCRIPTION
## Summary

**Phase 5 (final)** of the [unified master-data control design](https://github.com/e7217/edg/blob/main/docs/superpowers/specs/2026-06-18-unified-master-data-control-design.md): a small **embedded operator UI** so humans can see and edit master data without external tooling — closing the loop the whole design was built toward.

## What changed

- **`internal/webui`**: a single `go:embed`ded vanilla-JS SPA (zero build step, committed `dist/index.html`). Lists assets / relations / templates / constraint violations; asset & relation create/delete forms; a bearer-token field (localStorage) for writes; on-demand refresh.
- **httpapi**: serves the UI at `/` when `http.webui_enabled` is true (the `/api/v1/...` patterns take precedence in the Go 1.22 mux). New **read endpoints**: `GET /api/v1/templates`, `/templates/{name}` (the Phase-4-deferred template reads), and `/constraints` (catalog report via new `MetadataService.CheckConstraints`).
- **config**: `http.webui_enabled` toggle, wired through `main.go`, enabled in the dev config.

## Scope note

Live push (SSE) updates are **deferred** (documented) — the UI refreshes on demand; wiring NATS into the HTTP layer was kept out to limit risk. Same-origin serving means reads are anonymous while writes still require a token (Phase 3 rule).

## Tests

- `GET /templates` (list + by-name + 404), `GET /constraints`, and UI serving (disabled → root 404; enabled → root serves the embedded HTML while `/api/v1/health` still returns JSON). Existing httpapi/core tests still pass.

## Verification

```
go build ./...   # ok
go vet ./...      # clean
go test ./...     # all packages ok
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HUdtJkgqoi5UmN3fAifmAu